### PR TITLE
Add hotkeys to launch firefox modes

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,0 +1,7 @@
+{
+    "Always_use_Firefox_Private_Browsing": {"message": "Always use Firefox Private Browsing"},
+    "Launch_this_page_in_Firefox_Private_Browsing": {"message": "Launch this page in Firefox Private Browsing"},
+    "Launch_this_page_in_Firefox": {"message": "Launch this page in Firefox"},
+    "Launch_this_link_in_Firefox_Private_Browsing": {"message": "Launch this link in Firefox Private Browsing"},
+    "Launch_this_link_in_Firefox": {"message": "Launch this link in Firefox"} 
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,19 +1,99 @@
-// -------- Initialization ------
+// -------------------------------------------
+//          Browser Launching Logic
+// -------------------------------------------
 let isCurrentTabValidUrlScheme = false;
 
-async function getIsFirefoxDefault() {
-  return new Promise((resolve) => {
-    chrome.storage.sync.get(["isFirefoxDefault"], (result) => {
-      if (result.isFirefoxDefault === undefined) {
-        resolve(true);
-      } else {
-        resolve(result.isFirefoxDefault);
-      }
-    });
-  });
+function checkAndUpdateURLScheme(tab) {
+  if (tab.url === undefined) isCurrentTabValidUrlScheme = false;
+  else if (tab.url.startsWith("http") || tab.url.startsWith("file")) {
+    isCurrentTabValidUrlScheme = true;
+  } else {
+    isCurrentTabValidUrlScheme = false;
+  }
+}
+  
+function launchFirefox(tab, launchDefaultBrowsing) {
+  if (isCurrentTabValidUrlScheme) {
+    if (launchDefaultBrowsing) {
+      chrome.tabs.update(tab.id, {url: "firefox:" + tab.url});
+    } else {
+      chrome.tabs.update(tab.id, {url: "firefox-private:" + tab.url});
+    }
+  }
 }
 
-// ------ Icon ------
+// -------------------------------------------
+//            Context Menu Logic
+// -------------------------------------------
+function initContextMenu(isFirefoxDefault) {
+  // action context menu
+  chrome.contextMenus.create({
+    id: "changeDefaultLaunchContextMenu",
+    title: chrome.i18n.getMessage("Always_use_Firefox_Private_Browsing"),
+    contexts: ["action"],
+    type: "checkbox",
+    checked: !isFirefoxDefault,
+  });
+  chrome.contextMenus.create({
+    id: "alternativeLaunchContextMenu",
+    title: chrome.i18n.getMessage("Launch_this_page_in_Firefox_Private_Browsing"),
+    contexts: ["action"],
+  });
+  
+  // page context menu
+  chrome.contextMenus.create({
+    id: "launchInFirefox",
+    title: chrome.i18n.getMessage("Launch_this_page_in_Firefox"),
+    contexts: ["page"],
+  });
+  chrome.contextMenus.create({
+    id: "launchInFirefoxPrivate",
+    title: chrome.i18n.getMessage("Launch_this_page_in_Firefox_Private_Browsing"),
+    contexts: ["page"],
+  });
+  
+  chrome.contextMenus.create({
+    id: "launchInFirefoxLink",
+    title: chrome.i18n.getMessage("Launch_this_link_in_Firefox"),
+    contexts: ["link"],
+  });
+  chrome.contextMenus.create({
+    id: "launchInFirefoxPrivateLink",
+    title: chrome.i18n.getMessage("Launch_this_link_in_Firefox_Private_Browsing"),
+    contexts: ["link"],
+  });
+}
+  
+function handleContextMenuClick(info, tab, isFirefoxDefault) {
+  if (info.menuItemId === "changeDefaultLaunchContextMenu") {
+    chrome.contextMenus.update("changeDefaultLaunchContextMenu", {
+      type: "checkbox",
+      checked: isFirefoxDefault,
+    });
+    if (isFirefoxDefault) {
+      chrome.contextMenus.update("alternativeLaunchContextMenu", {
+        title: chrome.i18n.getMessage("Launch_this_page_in_Firefox"),
+      });
+    } else {
+      chrome.contextMenus.update("alternativeLaunchContextMenu", {
+        title: chrome.i18n.getMessage("Launch_this_page_in_Firefox_Private_Browsing"),
+      });
+    }
+    chrome.storage.sync.set({isFirefoxDefault: !isFirefoxDefault});
+    updateToolbarIcon(isFirefoxDefault);
+  } else if (info.menuItemId === "alternativeLaunchContextMenu") {
+    // launch in the opposite mode to the default
+    launchFirefox(tab, !isFirefoxDefault);
+  } else if (info.menuItemId === "launchInFirefox" || info.menuItemId === "launchInFirefoxLink") {
+    launchFirefox(tab, true);
+  } else if (info.menuItemId === "launchInFirefoxPrivate" || info.menuItemId === "launchInFirefoxPrivateLink") {
+    launchFirefox(tab, false);
+  }
+}
+
+// -------------------------------------------
+//            Toolbar Icon Logic
+// -------------------------------------------
 function updateToolbarIcon(isFirefoxDefault) {
   let iconPath = isFirefoxDefault ?
     {
@@ -31,119 +111,55 @@ function updateToolbarIcon(isFirefoxDefault) {
         32: "images/private32grey.png",
       };
   }
-
+  
   chrome.action.setIcon({path: iconPath});
 }
-
-// ------ Context Menu ------
-function initContextMenu(isFirefoxDefault) {
-  // action context menu
-  chrome.contextMenus.create({
-    id: "changeDefaultLaunchContextMenu",
-    title: "Always use Firefox Private Browsing",
-    contexts: ["action"],
-    type: "checkbox",
-    checked: !isFirefoxDefault,
-  });
-  chrome.contextMenus.create({
-    id: "alternativeLaunchContextMenu",
-    title: "Launch this page in Firefox Private Browsing",
-    contexts: ["action"],
-  });
-
-  // page context menu
-  chrome.contextMenus.create({
-    id: "launchInFirefox",
-    title: "Launch this page in Firefox",
-    contexts: ["page"],
-  });
-  chrome.contextMenus.create({
-    id: "launchInFirefoxPrivate",
-    title: "Launch this page in Firefox Private Browsing",
-    contexts: ["page"],
-  });
-
-  chrome.contextMenus.create({
-    id: "launchInFirefoxLink",
-    title: "Launch this link in Firefox",
-    contexts: ["link"],
-  });
-  chrome.contextMenus.create({
-    id: "launchInFirefoxPrivateLink",
-    title: "Launch this link in Firefox Private Browsing",
-    contexts: ["link"],
-  });
-}
-
-function handleContextMenuClick(info, tab, isFirefoxDefault) {
-  if (info.menuItemId === "changeDefaultLaunchContextMenu") {
-    chrome.contextMenus.update("changeDefaultLaunchContextMenu", {
-      type: "checkbox",
-      checked: isFirefoxDefault,
-    });
-    if (isFirefoxDefault) {
-      chrome.contextMenus.update("alternativeLaunchContextMenu", {
-        title: "Launch this page in Firefox",
-      });
-    } else {
-      chrome.contextMenus.update("alternativeLaunchContextMenu", {
-        title: "Launch this page in Firefox Private Browsing",
-      });
-    }
-    chrome.storage.sync.set({isFirefoxDefault: !isFirefoxDefault});
-    updateToolbarIcon(isFirefoxDefault);
-  } else if (info.menuItemId === "alternativeLaunchContextMenu") {
-    // launch in the opposite mode to the default
-    launchFirefox(tab, !isFirefoxDefault);
-  } else if (info.menuItemId === "launchInFirefox" || info.menuItemId === "launchInFirefoxLink") {
+  
+// -------------------------------------------
+//              Hotkey Logic
+// -------------------------------------------
+function handleHotkeyPress(command, tab) {
+  if (command === "launchFirefox") {
     launchFirefox(tab, true);
-  } else if (info.menuItemId === "launchInFirefoxPrivate" || info.menuItemId === "launchInFirefoxPrivateLink") {
+  } else if (command === "launchFirefoxPrivate") {
     launchFirefox(tab, false);
   }
+}
+
+// -------------------------------------------
+//             Event Listeners
+// -------------------------------------------
+async function getIsFirefoxDefault() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(["isFirefoxDefault"], (result) => {
+      if (result.isFirefoxDefault === undefined) {
+        resolve(true);
+      } else {
+        resolve(result.isFirefoxDefault);
+      }
+    });
+  });
 }
 
 chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   handleContextMenuClick(info, tab, await getIsFirefoxDefault());
 });
 
-// ------ Installation ------
 chrome.runtime.onInstalled.addListener(async () => {
   const isFirefoxDefault = await getIsFirefoxDefault();
   initContextMenu(isFirefoxDefault);
   updateToolbarIcon(isFirefoxDefault);
 });
 
-// ------ Storage listeners ------
 chrome.storage.sync.onChanged.addListener(async (changes) => {
   if (changes.isFirefoxDefault !== undefined) {
     updateToolbarIcon(await getIsFirefoxDefault());
   }
 });
 
-// ------ Launching Firefox ------
-function launchFirefox(tab, launchDefaultBrowsing) {
-  if (isCurrentTabValidUrlScheme) {
-    if (launchDefaultBrowsing) {
-      chrome.tabs.update(tab.id, {url: "firefox:" + tab.url});
-    } else {
-      chrome.tabs.update(tab.id, {url: "firefox-private:" + tab.url});
-    }
-  }
-}
-
 chrome.action.onClicked.addListener(async (tab) => {
   launchFirefox(tab, await getIsFirefoxDefault());
 });
-
-// ------ Grey Icon Logic --------
-function checkAndUpdateURLScheme(tab) {
-  if (tab.url === undefined) isCurrentTabValidUrlScheme = false;
-  else if (tab.url.startsWith("http") || tab.url.startsWith("file")) {
-    isCurrentTabValidUrlScheme = true;
-  } else {
-    isCurrentTabValidUrlScheme = false;
-  }
-}
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   checkAndUpdateURLScheme(tab);
@@ -162,18 +178,26 @@ chrome.tabs.onActivated.addListener((activeInfo) => {
   });
 });
 
+chrome.commands.onCommand.addListener((command) => {
+  console.log("Command:", command);
+  chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+    handleHotkeyPress(command, tabs[0]);
+  });
+});
 
-// ------ Exports ------
-if (chrome.isTestEnv) {
-  chrome.initContextMenu = initContextMenu;
-  chrome.handleContextMenuClick = handleContextMenuClick;
-  chrome.launchFirefox = launchFirefox;
-  chrome.checkAndUpdateURLScheme = checkAndUpdateURLScheme;
-  chrome.updateToolbarIcon = updateToolbarIcon;
-  chrome.setIsCurrentTabValidUrlScheme = (value) => {
-    isCurrentTabValidUrlScheme = value;
-  };
-  chrome.getIsCurrentTabValidUrlScheme = () => {
-    return isCurrentTabValidUrlScheme;
-  };
-}
+// -------------------------------------------
+//              Exports
+// -------------------------------------------
+chrome.launchFirefox = launchFirefox;
+chrome.checkAndUpdateURLScheme = checkAndUpdateURLScheme;
+chrome.updateToolbarIcon = updateToolbarIcon;
+chrome.handleHotkeyPress = handleHotkeyPress;
+chrome.initContextMenu = initContextMenu;
+chrome.handleContextMenuClick = handleContextMenuClick;
+chrome.getIsFirefoxDefault = getIsFirefoxDefault;
+chrome.setIsCurrentTabValidUrlScheme = (value) => {
+  isCurrentTabValidUrlScheme = value;
+};
+chrome.getIsCurrentTabValidUrlScheme = () => {
+  return isCurrentTabValidUrlScheme;
+};

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,10 +14,12 @@
     "contextMenus",
     "activeTab",
     "tabs",
-    "storage"
+    "storage",
+    "commands"
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "action": {
     "default_icon": {
@@ -27,5 +29,20 @@
       "96": "images/firefox96.png",
       "128": "images/firefox128.png"
     }
-  }
+  },
+  "commands": {
+    "launchFirefox": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+F"
+      },
+      "description": "Launch Firefox"
+    },
+    "launchFirefoxPrivate": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+P"
+      },
+      "description": "Launch Firefox Private Browsing"
+    }
+  },
+  "default_locale": "en"
 }

--- a/test/backgroundScripts/background.test.js
+++ b/test/backgroundScripts/background.test.js
@@ -1,9 +1,10 @@
 require("../setup.js");
 
-describe("Toolbar Context Menu", () => {
+describe("background.js", () => {
   describe("initContextMenu()", () => {
     it("should create the context menu", async () => {
-      global.chrome.initContextMenu();
+      const isFirefoxDefault = true;
+      global.chrome.initContextMenu(isFirefoxDefault);
       expect(global.chrome.contextMenus.create.callCount).to.equal(6);
       expect(global.chrome.contextMenus.create).to.have.been.calledWith({
         id: "changeDefaultLaunchContextMenu",
@@ -43,8 +44,8 @@ describe("Toolbar Context Menu", () => {
 
   describe("handleContextMenuClick()", () => {
     it("should change the default launch mode to private", async () => {
-      global.chrome.setIsFirefoxDefault(true);
-      global.chrome.handleContextMenuClick({menuItemId: "changeDefaultLaunchContextMenu"});
+      const isFirefoxDefault = true;
+      global.chrome.handleContextMenuClick({menuItemId: "changeDefaultLaunchContextMenu"}, {}, isFirefoxDefault);
       expect(global.chrome.contextMenus.update).to.have.been.calledTwice;
       expect(global.chrome.contextMenus.update).to.have.been.calledWith("changeDefaultLaunchContextMenu", {
         type: "checkbox",
@@ -53,11 +54,12 @@ describe("Toolbar Context Menu", () => {
       expect(global.chrome.contextMenus.update).to.have.been.calledWith("alternativeLaunchContextMenu", {
         title: "Launch this page in Firefox",
       });
+
     });
 
     it("should change the default launch mode to normal", async () => {
-      global.chrome.setIsFirefoxDefault(false);
-      global.chrome.handleContextMenuClick({menuItemId: "changeDefaultLaunchContextMenu"});
+      const isFirefoxDefault = false;
+      global.chrome.handleContextMenuClick({menuItemId: "changeDefaultLaunchContextMenu"}, {}, isFirefoxDefault);
       expect(global.chrome.contextMenus.update).to.have.been.calledTwice;
       expect(global.chrome.contextMenus.update).to.have.been.calledWith("changeDefaultLaunchContextMenu", {
         type: "checkbox",
@@ -69,17 +71,16 @@ describe("Toolbar Context Menu", () => {
     });
 
     it("should launch firefox in the alternative launch mode to default", async () => {
-      global.chrome.setIsFirefoxDefault(true);
+      const isFirefoxDefault = true;
       global.chrome.setIsCurrentTabValidUrlScheme(true);
-      global.chrome.handleContextMenuClick({menuItemId: "alternativeLaunchContextMenu"}, {id: 1, url: "https://basicurl.com"});
+      global.chrome.handleContextMenuClick({menuItemId: "alternativeLaunchContextMenu"}, {id: 1, url: "https://basicurl.com"}, isFirefoxDefault);
       expect(global.chrome.tabs.update).to.have.been.calledOnce;
       expect(global.chrome.tabs.update).to.have.been.calledWith(1, {
         url: "firefox-private:https://basicurl.com",
       });
 
-      global.chrome.setIsFirefoxDefault(false);
       global.chrome.setIsCurrentTabValidUrlScheme(true);
-      global.chrome.handleContextMenuClick({menuItemId: "alternativeLaunchContextMenu"}, {id: 1, url: "https://basicurl.com"});
+      global.chrome.handleContextMenuClick({menuItemId: "alternativeLaunchContextMenu"}, {id: 1, url: "https://basicurl.com"}, !isFirefoxDefault);
       expect(global.chrome.tabs.update).to.have.been.calledTwice;
       expect(global.chrome.tabs.update).to.have.been.calledWith(1, {
         url: "firefox:https://basicurl.com",
@@ -87,9 +88,9 @@ describe("Toolbar Context Menu", () => {
     });
 
     it("should launch firefox in normal mode from the page context", async () => {
-      global.chrome.setIsFirefoxDefault(true);
+      const isFirefoxDefault = true;
       global.chrome.setIsCurrentTabValidUrlScheme(true);
-      global.chrome.handleContextMenuClick({menuItemId: "launchInFirefox"}, {id: 1, url: "https://basicurl.com"});
+      global.chrome.handleContextMenuClick({menuItemId: "launchInFirefox"}, {id: 1, url: "https://basicurl.com"}, isFirefoxDefault);
       expect(global.chrome.tabs.update).to.have.been.calledOnce;
       expect(global.chrome.tabs.update).to.have.been.calledWith(1, {
         url: "firefox:https://basicurl.com",
@@ -97,9 +98,9 @@ describe("Toolbar Context Menu", () => {
     });
 
     it("should launch firefox in private mode from the page context", async () => {
-      global.chrome.setIsFirefoxDefault(false);
+      const isFirefoxDefault = false;
       global.chrome.setIsCurrentTabValidUrlScheme(true);
-      global.chrome.handleContextMenuClick({menuItemId: "launchInFirefoxPrivate"}, {id: 1, url: "https://basicurl.com"});
+      global.chrome.handleContextMenuClick({menuItemId: "launchInFirefoxPrivate"}, {id: 1, url: "https://basicurl.com"}, isFirefoxDefault);
       expect(global.chrome.tabs.update).to.have.been.calledOnce;
       expect(global.chrome.tabs.update).to.have.been.calledWith(1, {
         url: "firefox-private:https://basicurl.com",
@@ -107,9 +108,9 @@ describe("Toolbar Context Menu", () => {
     });
 
     it("should launch firefox in normal mode from the link context", async () => {
-      global.chrome.setIsFirefoxDefault(true);
+      const isFirefoxDefault = true;
       global.chrome.setIsCurrentTabValidUrlScheme(true);
-      global.chrome.handleContextMenuClick({menuItemId: "launchInFirefoxLink"}, {id: 1, url: "https://basicurl.com"});
+      global.chrome.handleContextMenuClick({menuItemId: "launchInFirefoxLink"}, {id: 1, url: "https://basicurl.com"}, isFirefoxDefault);
       expect(global.chrome.tabs.update).to.have.been.calledOnce;
       expect(global.chrome.tabs.update).to.have.been.calledWith(1, {
         url: "firefox:https://basicurl.com",
@@ -117,9 +118,9 @@ describe("Toolbar Context Menu", () => {
     });
 
     it("should launch firefox in private mode from the link context", async () => {
-      global.chrome.setIsFirefoxDefault(false);
+      const isFirefoxDefault = false;
       global.chrome.setIsCurrentTabValidUrlScheme(true);
-      global.chrome.handleContextMenuClick({menuItemId: "launchInFirefoxPrivateLink"}, {id: 1, url: "https://basicurl.com"});
+      global.chrome.handleContextMenuClick({menuItemId: "launchInFirefoxPrivateLink"}, {id: 1, url: "https://basicurl.com"}, isFirefoxDefault);
       expect(global.chrome.tabs.update).to.have.been.calledOnce;
       expect(global.chrome.tabs.update).to.have.been.calledWith(1, {
         url: "firefox-private:https://basicurl.com",
@@ -129,9 +130,9 @@ describe("Toolbar Context Menu", () => {
 
   describe("updateToolbarIcon()", () => {
     it("should update the toolbar icon to firefox icon grey colour", async () => {
-      global.chrome.setIsFirefoxDefault(true);
+      const isFirefoxDefault = true;
       global.chrome.setIsCurrentTabValidUrlScheme(false);
-      global.chrome.updateToolbarIcon();
+      global.chrome.updateToolbarIcon(isFirefoxDefault);
       expect(global.chrome.action.setIcon).to.have.been.calledOnce;
       expect(global.chrome.action.setIcon).to.have.been.calledWith({
         path: {
@@ -141,9 +142,9 @@ describe("Toolbar Context Menu", () => {
     });
 
     it("should update the toolbar icon to private browsing icon grey colour", async () => {
-      global.chrome.setIsFirefoxDefault(false);
+      const isFirefoxDefault = false;
       global.chrome.setIsCurrentTabValidUrlScheme(false);
-      global.chrome.updateToolbarIcon();
+      global.chrome.updateToolbarIcon(isFirefoxDefault);
       expect(global.chrome.action.setIcon).to.have.been.calledOnce;
       expect(global.chrome.action.setIcon).to.have.been.calledWith({
         path: {
@@ -153,9 +154,9 @@ describe("Toolbar Context Menu", () => {
     });
 
     it("should update the toolbar icon to firefox icon", async () => {
-      global.chrome.setIsFirefoxDefault(true);
+      const isFirefoxDefault = true;
       global.chrome.setIsCurrentTabValidUrlScheme(true);
-      global.chrome.updateToolbarIcon();
+      global.chrome.updateToolbarIcon(isFirefoxDefault);
       expect(global.chrome.action.setIcon).to.have.been.calledOnce;
       expect(global.chrome.action.setIcon).to.have.been.calledWith({
         path: {
@@ -165,9 +166,9 @@ describe("Toolbar Context Menu", () => {
     });
 
     it("should update the toolbar icon to private browsing icon", async () => {
-      global.chrome.setIsFirefoxDefault(false);
+      const isFirefoxDefault = false;
       global.chrome.setIsCurrentTabValidUrlScheme(true);
-      global.chrome.updateToolbarIcon();
+      global.chrome.updateToolbarIcon(isFirefoxDefault);
       expect(global.chrome.action.setIcon).to.have.been.calledOnce;
       expect(global.chrome.action.setIcon).to.have.been.calledWith({
         path: {
@@ -179,8 +180,9 @@ describe("Toolbar Context Menu", () => {
 
   describe("launchFirefox()", () => {
     it("should launch firefox in private mode", async () => {
+      const isFirefoxDefault = false;
       global.chrome.setIsCurrentTabValidUrlScheme(true);
-      global.chrome.launchFirefox({id: 1, url: "https://addons.mozilla.org/en-CA/firefox/extensions/"}, false);
+      global.chrome.launchFirefox({id: 1, url: "https://addons.mozilla.org/en-CA/firefox/extensions/"}, isFirefoxDefault);
       expect(global.chrome.tabs.update).to.have.been.calledOnce;
       expect(global.chrome.tabs.update).to.have.been.calledWith(1, {
         url: "firefox-private:https://addons.mozilla.org/en-CA/firefox/extensions/",
@@ -188,8 +190,9 @@ describe("Toolbar Context Menu", () => {
     });
 
     it("should launch firefox in normal mode", async () => {
+      const isFirefoxDefault = true;
       global.chrome.setIsCurrentTabValidUrlScheme(true);
-      global.chrome.launchFirefox({id: 1, url: "https://addons.mozilla.org/en-CA/firefox/extensions/"}, true);
+      global.chrome.launchFirefox({id: 1, url: "https://addons.mozilla.org/en-CA/firefox/extensions/"}, isFirefoxDefault);
       expect(global.chrome.tabs.update).to.have.been.calledOnce;
       expect(global.chrome.tabs.update).to.have.been.calledWith(1, {
         url: "firefox:https://addons.mozilla.org/en-CA/firefox/extensions/",
@@ -202,28 +205,24 @@ describe("Toolbar Context Menu", () => {
       global.chrome.setIsCurrentTabValidUrlScheme(true);
       global.chrome.checkAndUpdateURLScheme({id: 1});
       expect(global.chrome.getIsCurrentTabValidUrlScheme()).to.be.false;
-      expect(chrome.action.setIcon).to.have.been.calledOnce;
     });
 
     it("should set the current tab url scheme to be false if it is not http or file", async () => {
       global.chrome.setIsCurrentTabValidUrlScheme(true);
       global.chrome.checkAndUpdateURLScheme({id: 1, url: "about:blank"});
       expect(global.chrome.getIsCurrentTabValidUrlScheme()).to.be.false;
-      expect(chrome.action.setIcon).to.have.been.calledOnce;  
     });
 
     it("should set the current tab url scheme to be true if it is http", async () => {
       global.chrome.setIsCurrentTabValidUrlScheme(false);
       global.chrome.checkAndUpdateURLScheme({id: 1, url: "http://www.google.com"});
       expect(global.chrome.getIsCurrentTabValidUrlScheme()).to.be.true;
-      expect(chrome.action.setIcon).to.have.been.calledOnce;  
     });
 
     it("should set the current tab url scheme to be true if it is file", async () => {
       global.chrome.setIsCurrentTabValidUrlScheme(false);
       global.chrome.checkAndUpdateURLScheme({id: 1, url: "file://C:/Users"});
       expect(global.chrome.getIsCurrentTabValidUrlScheme()).to.be.true;
-      expect(chrome.action.setIcon).to.have.been.calledOnce;  
     });
   });
 });

--- a/test/backgroundScripts/background.test.js
+++ b/test/backgroundScripts/background.test.js
@@ -225,4 +225,31 @@ describe("background.js", () => {
       expect(global.chrome.getIsCurrentTabValidUrlScheme()).to.be.true;
     });
   });
+
+  describe("handleHotkeyPress()", () => {
+
+    it("should launch firefox in normal mode", async () => {
+      global.chrome.setIsCurrentTabValidUrlScheme(true);
+      global.chrome.handleHotkeyPress("launchFirefox", {id: 1, url: "https://addons.mozilla.org/en-CA/firefox/extensions/"});
+      expect(global.chrome.tabs.update).to.have.been.calledOnce;
+      expect(global.chrome.tabs.update).to.have.been.calledWith(1, {
+        url: "firefox:https://addons.mozilla.org/en-CA/firefox/extensions/",
+      });
+    });
+
+    it("should launch firefox in private mode", async () => {
+      global.chrome.setIsCurrentTabValidUrlScheme(true);
+      global.chrome.handleHotkeyPress("launchFirefoxPrivate", {id: 1, url: "https://addons.mozilla.org/en-CA/firefox/extensions/"});
+      expect(global.chrome.tabs.update).to.have.been.calledOnce;
+      expect(global.chrome.tabs.update).to.have.been.calledWith(1, {
+        url: "firefox-private:https://addons.mozilla.org/en-CA/firefox/extensions/",
+      });
+    });
+
+    it("should do nothing if the command is not recognized", async () => {
+      global.chrome.setIsCurrentTabValidUrlScheme(true);
+      global.chrome.handleHotkeyPress("notvalid", {id: 1, url: "https://addons.mozilla.org/en-CA/firefox/extensions/"});
+      expect(global.chrome.tabs.update).to.not.have.been.called;
+    });
+  });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -45,8 +45,20 @@ global.chrome = {
       addListener: sinon.stub(),
     },
     update: sinon.stub(),
-  }
+  },
+  commands: {
+    onCommand: {
+      addListener: sinon.stub(),
+    },
+  },
+  i18n: {
+    getMessage: sinon.stub(),
+  },
 };
+// replace underscores with spaces
+global.chrome.i18n.getMessage.callsFake((key) => key.replace(/_/g, " "));
+
+// load background script now
 require(path.join(__dirname, "../src/background.js"));
 
 global.afterEach(() => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -62,6 +62,5 @@ global.afterEach(() => {
   global.chrome.tabs.onActivated.addListener.reset();
   global.chrome.tabs.onCreated.addListener.reset();
   global.chrome.runtime.onInstalled.addListener.reset();
-  global.chrome.storage.sync.onChanged.addListener.reset();
   global.chrome.contextMenus.onClicked.addListener.reset();
 });


### PR DESCRIPTION
Fixes [Jira issue](https://mozilla-hub.atlassian.net/browse/AMO-131)

Hotkeys are assigned on installation of the extension. This change attempts to assign `ctrl/cmd+shift+f/p` to the proper launch mode, but if they have been taken by another program, does not set the hotkey. In this case, the user has to navigate to `chrome://extensions/shortcuts` or equivalent to set the desired hotkeys.

![Screenshot 2023-12-01 at 11 30 24 AM](https://github.com/mozilla/firefox-launch/assets/63402349/53bdf7aa-da17-4972-96d5-94865b7ff71e)

Also reorganize background.js.
