### PR TITLE
Code Review: Rename openPrivilegedUrl to openShortcutsPage

### DIFF
--- a/src/firefox/api.js
+++ b/src/firefox/api.js
@@ -183,9 +183,9 @@ this.experiments_firefox_launch = class extends ExtensionAPI {
             }
           },
 
-          openPrivilegedUrl(url) {
+          openShortcutsPage() {
             let win = Services.wm.getMostRecentWindow("navigator:browser");
-            win.BrowserOpenAddonsMgr(url);
+            win.BrowserOpenAddonsMgr("addons://shortcuts/shortcuts");
           }
         },
       },

--- a/src/firefox/schema.json
+++ b/src/firefox/schema.json
@@ -40,17 +40,11 @@
         ]
       },
       {
-        "name": "openPrivilegedUrl",
+        "name": "openShortcutsPage",
         "type": "function",
         "async": false,
-        "description": "Opens a privileged URL in the browser",
-        "parameters": [
-          {
-            "name": "url",
-            "type": "string",
-            "description": "The URL to open"
-          }
-        ]
+        "description": "Opens the Firefox addons shortcuts page.",
+        "parameters": []
       }
     ]
   }

--- a/src/shared/pages/welcomePage/localization.js
+++ b/src/shared/pages/welcomePage/localization.js
@@ -17,7 +17,7 @@ export function replaceMessage(element, l10nID, href) {
     link.addEventListener("click", (event) => {
       event.preventDefault();
       if (href.startsWith("addons://")) {
-        browser.experiments.firefox_launch.openPrivilegedUrl(href);
+        browser.experiments.firefox_launch.openShortcutsPage();
       } else {
         browser.tabs.create({
           url: href,


### PR DESCRIPTION
This patch renames openPrivilegedUrl to openShortcutsPage and removes the url parameter since it is only used to launch one URL. Handling the other references to "addons://" will be done in a future patch related to https://github.com/mozilla/firefox-launch/pull/18#discussion_r1468662523 and the special case

A future patch can rid this requirement altogether with the implementation of this bugzilla ticket: [Make extension shortcut management page accessible by a link/URL for a WebExtension](https://bugzilla.mozilla.org/show_bug.cgi?id=1538451)

Code Review comments:
- https://github.com/mozilla/firefox-launch/pull/18#discussion_r1468664417