### PR TITLE
Code Review: Use url parameter instead of tab

### DIFF
--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -105,9 +105,9 @@ export async function handleChangeDefaultLaunchContextMenuClick() {
  * Handles the context menu clicks for the Chromium Extension.
  *
  * @param {*} info  The context menu item info object.
- * @param {string} url  The url the context menu will handle.
+ * @param {*} tab  The tab object to launch the browser with.
  */
-export async function handlePlatformContextMenuClick(info, url) {
+export async function handlePlatformContextMenuClick(info, tab) {
   const externalBrowserName = await getExternalBrowser();
 
   if (info.menuItemId === "changeDefaultLaunchContextMenu") {
@@ -125,7 +125,7 @@ export async function handlePlatformContextMenuClick(info, url) {
     });
   } else if (info.menuItemId === "alternativeLaunchContextMenu") {
     // launch in the opposite mode to the default
-    if (await launchBrowser(url, externalBrowserName === "Firefox")) {
+    if (await launchBrowser(tab.url, externalBrowserName === "Firefox")) {
       const launchedBrowserName =
         (await getExternalBrowser()) === "Firefox"
           ? "Firefox Private Browsing"
@@ -139,7 +139,7 @@ export async function handlePlatformContextMenuClick(info, url) {
       });
     }
   } else if (info.menuItemId === "launchInExternalBrowserPrivate") {
-    if (await launchBrowser(url, true)) {
+    if (await launchBrowser(tab.url, true)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",
@@ -149,7 +149,7 @@ export async function handlePlatformContextMenuClick(info, url) {
       });
     }
   } else if (info.menuItemId === "launchInExternalBrowserPrivateLink") {
-    if (await launchBrowser(url, true)) {
+    if (await launchBrowser(info.linkUrl, true)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",

--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -61,6 +61,7 @@ export async function applyPlatformContextMenus() {
       "Firefox Private Browsing",
     ),
     contexts: ["page"],
+    documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
   });
 
   // link context menu
@@ -71,6 +72,7 @@ export async function applyPlatformContextMenus() {
       "Firefox Private Browsing",
     ),
     contexts: ["link"],
+    targetUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
   });
 }
 

--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -105,9 +105,9 @@ export async function handleChangeDefaultLaunchContextMenuClick() {
  * Handles the context menu clicks for the Chromium Extension.
  *
  * @param {*} info  The context menu item info object.
- * @param {*} tab  The tab object to launch the browser with.
+ * @param {string} url  The url the context menu will handle.
  */
-export async function handlePlatformContextMenuClick(info, tab) {
+export async function handlePlatformContextMenuClick(info, url) {
   const externalBrowserName = await getExternalBrowser();
 
   if (info.menuItemId === "changeDefaultLaunchContextMenu") {
@@ -125,7 +125,7 @@ export async function handlePlatformContextMenuClick(info, tab) {
     });
   } else if (info.menuItemId === "alternativeLaunchContextMenu") {
     // launch in the opposite mode to the default
-    if (await launchBrowser(tab, externalBrowserName === "Firefox")) {
+    if (await launchBrowser(url, externalBrowserName === "Firefox")) {
       const launchedBrowserName =
         (await getExternalBrowser()) === "Firefox"
           ? "Firefox Private Browsing"
@@ -139,7 +139,7 @@ export async function handlePlatformContextMenuClick(info, tab) {
       });
     }
   } else if (info.menuItemId === "launchInExternalBrowserPrivate") {
-    if (await launchBrowser(tab, true)) {
+    if (await launchBrowser(url, true)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",
@@ -149,8 +149,7 @@ export async function handlePlatformContextMenuClick(info, tab) {
       });
     }
   } else if (info.menuItemId === "launchInExternalBrowserPrivateLink") {
-    tab.url = info.linkUrl;
-    if (await launchBrowser(tab, true)) {
+    if (await launchBrowser(url, true)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",

--- a/src/chromium/interfaces/launchBrowser.js
+++ b/src/chromium/interfaces/launchBrowser.js
@@ -15,7 +15,10 @@ export async function launchBrowser(url, usePrivateBrowsing = false) {
   }
 
   if (isCurrentTabValidUrlScheme) {
-    const currentTab = await browser.tabs.query({ active: true, currentWindow: true });
+    const currentTab = await browser.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
     const currentTabId = currentTab[0].id;
     if (usePrivateBrowsing) {
       browser.tabs.update(currentTabId, { url: "firefox-private:" + url });

--- a/src/chromium/interfaces/launchBrowser.js
+++ b/src/chromium/interfaces/launchBrowser.js
@@ -15,7 +15,8 @@ export async function launchBrowser(url, usePrivateBrowsing = false) {
   }
 
   if (isCurrentTabValidUrlScheme) {
-    const currentTabId = await browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => tabs[0].id);
+    const currentTab = await browser.tabs.query({ active: true, currentWindow: true });
+    const currentTabId = currentTab[0].id;
     if (usePrivateBrowsing) {
       browser.tabs.update(currentTabId, { url: "firefox-private:" + url });
     } else {

--- a/src/chromium/interfaces/launchBrowser.js
+++ b/src/chromium/interfaces/launchBrowser.js
@@ -1,3 +1,4 @@
+import { isURLValid } from "Shared/backgroundScripts/validTab.js";
 import { getIsFirefoxInstalled } from "./getters.js";
 
 /**
@@ -8,12 +9,7 @@ import { getIsFirefoxInstalled } from "./getters.js";
  * @returns {boolean} True if the browser was launched, false otherwise.
  */
 export async function launchBrowser(url, usePrivateBrowsing = false) {
-  if (
-    url &&
-    !url.startsWith("https:") &&
-    !url.startsWith("http:") &&
-    !url.startsWith("file:")
-  ) {
+  if (!isURLValid(url)) {
     console.error("Invalid URL scheme:", url);
     return false;
   }

--- a/src/chromium/interfaces/launchBrowser.js
+++ b/src/chromium/interfaces/launchBrowser.js
@@ -1,5 +1,4 @@
 import { getIsFirefoxInstalled } from "./getters.js";
-import { isCurrentTabValidUrlScheme } from "Shared/backgroundScripts/validTab.js";
 
 /**
  * Launches the Firefox variant. If Firefox is not installed, launch the Firefox download page.
@@ -9,23 +8,30 @@ import { isCurrentTabValidUrlScheme } from "Shared/backgroundScripts/validTab.js
  * @returns {boolean} True if the browser was launched, false otherwise.
  */
 export async function launchBrowser(url, usePrivateBrowsing = false) {
+  if (
+    url &&
+    !url.startsWith("https:") &&
+    !url.startsWith("http:") &&
+    !url.startsWith("file:")
+  ) {
+    console.error("Invalid URL scheme:", url);
+    return false;
+  }
+
   if (!(await getIsFirefoxInstalled())) {
     browser.tabs.create({ url: "https://www.mozilla.org/firefox/" });
     return false;
   }
 
-  if (isCurrentTabValidUrlScheme) {
-    const currentTab = await browser.tabs.query({
-      active: true,
-      currentWindow: true,
-    });
-    const currentTabId = currentTab[0].id;
-    if (usePrivateBrowsing) {
-      browser.tabs.update(currentTabId, { url: "firefox-private:" + url });
-    } else {
-      browser.tabs.update(currentTabId, { url: "firefox:" + url });
-    }
-    return true;
+  const currentTab = await browser.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  const currentTabId = currentTab[0].id;
+  if (usePrivateBrowsing) {
+    browser.tabs.update(currentTabId, { url: "firefox-private:" + url });
+  } else {
+    browser.tabs.update(currentTabId, { url: "firefox:" + url });
   }
-  return false;
+  return true;
 }

--- a/src/chromium/interfaces/launchBrowser.js
+++ b/src/chromium/interfaces/launchBrowser.js
@@ -4,21 +4,22 @@ import { isCurrentTabValidUrlScheme } from "Shared/backgroundScripts/validTab.js
 /**
  * Launches the Firefox variant. If Firefox is not installed, launch the Firefox download page.
  *
- * @param {*} tab The tab object to launch the browser with.
+ * @param {string} url The url to launch in the browser.
  * @param {boolean} usePrivateBrowsing  True if firefox should be launched in private browsing mode, false for normal mode.
  * @returns {boolean} True if the browser was launched, false otherwise.
  */
-export async function launchBrowser(tab, usePrivateBrowsing = false) {
+export async function launchBrowser(url, usePrivateBrowsing = false) {
   if (!(await getIsFirefoxInstalled())) {
     browser.tabs.create({ url: "https://www.mozilla.org/firefox/" });
     return false;
   }
 
   if (isCurrentTabValidUrlScheme) {
+    const currentTabId = await browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => tabs[0].id);
     if (usePrivateBrowsing) {
-      browser.tabs.update(tab.id, { url: "firefox-private:" + tab.url });
+      browser.tabs.update(currentTabId, { url: "firefox-private:" + url });
     } else {
-      browser.tabs.update(tab.id, { url: "firefox:" + tab.url });
+      browser.tabs.update(currentTabId, { url: "firefox:" + url });
     }
     return true;
   }

--- a/src/chromium/interfaces/listeners.js
+++ b/src/chromium/interfaces/listeners.js
@@ -8,7 +8,7 @@ import { getExternalBrowser } from "Shared/backgroundScripts/getters.js";
 export function initPlatformListeners() {
   browser.action.onClicked.addListener(async (tab) => {
     const browserName = await getExternalBrowser();
-    const success = launchBrowser(tab, browserName !== "Firefox");
+    const success = launchBrowser(tab.url, browserName !== "Firefox");
     if (success) {
       browser.storage.local.set({
         telemetry: {

--- a/src/firefox/interfaces/launchBrowser.js
+++ b/src/firefox/interfaces/launchBrowser.js
@@ -1,4 +1,3 @@
-import { isCurrentTabValidUrlScheme } from "Shared/backgroundScripts/validTab.js";
 import { getExternalBrowserLaunchProtocol } from "./getters.js";
 
 /**
@@ -17,15 +16,23 @@ export async function launchBrowser(url, usePrivateBrowsing = false) {
     return false;
   }
 
-  if (isCurrentTabValidUrlScheme) {
-    const launchProtocol = await getExternalBrowserLaunchProtocol();
-    if (launchProtocol) {
-      browser.experiments.firefox_launch.launchApp(launchProtocol, [url]);
-      return true;
-    }
-    browser.tabs.create({
-      url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
-    });
+  if (
+    url &&
+    !url.startsWith("https:") &&
+    !url.startsWith("http:") &&
+    !url.startsWith("file:")
+  ) {
+    console.error("Invalid URL scheme:", url);
+    return false;
   }
+
+  const launchProtocol = await getExternalBrowserLaunchProtocol();
+  if (launchProtocol) {
+    browser.experiments.firefox_launch.launchApp(launchProtocol, [url]);
+    return true;
+  }
+  browser.tabs.create({
+    url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
+  });
   return false;
 }

--- a/src/firefox/interfaces/launchBrowser.js
+++ b/src/firefox/interfaces/launchBrowser.js
@@ -4,7 +4,7 @@ import { getExternalBrowserLaunchProtocol } from "./getters.js";
 /**
  * Launches the user set browser. If the browser is not set, launch the welcome page.
  *
- * @param {*} url The url to launch in the browser.
+ * @param {string} url The url to launch in the browser.
  * @param {boolean} usePrivateBrowsing True if the browser should be launched in private browsing mode, false for normal mode.
  * @returns {boolean} True if the browser was launched, false otherwise.
  */

--- a/src/firefox/interfaces/launchBrowser.js
+++ b/src/firefox/interfaces/launchBrowser.js
@@ -1,4 +1,5 @@
 import { getExternalBrowserLaunchProtocol } from "./getters.js";
+import { isURLValid } from "Shared/backgroundScripts/validTab.js";
 
 /**
  * Launches the user set browser. If the browser is not set, launch the welcome page.
@@ -16,12 +17,7 @@ export async function launchBrowser(url, usePrivateBrowsing = false) {
     return false;
   }
 
-  if (
-    url &&
-    !url.startsWith("https:") &&
-    !url.startsWith("http:") &&
-    !url.startsWith("file:")
-  ) {
+  if (!isURLValid(url)) {
     console.error("Invalid URL scheme:", url);
     return false;
   }

--- a/src/firefox/interfaces/launchBrowser.js
+++ b/src/firefox/interfaces/launchBrowser.js
@@ -4,14 +4,14 @@ import { getExternalBrowserLaunchProtocol } from "./getters.js";
 /**
  * Launches the user set browser. If the browser is not set, launch the welcome page.
  *
- * @param {*} tab The tab object to launch the browser with.
+ * @param {*} url The url to launch in the browser.
  * @returns {boolean} True if the browser was launched, false otherwise.
  */
-export async function launchBrowser(tab) {
+export async function launchBrowser(url) {
   if (isCurrentTabValidUrlScheme) {
     const launchProtocol = await getExternalBrowserLaunchProtocol();
     if (launchProtocol) {
-      browser.experiments.firefox_launch.launchApp(launchProtocol, [tab.url]);
+      browser.experiments.firefox_launch.launchApp(launchProtocol, [url]);
       return true;
     }
     browser.tabs.create({

--- a/src/firefox/interfaces/launchBrowser.js
+++ b/src/firefox/interfaces/launchBrowser.js
@@ -5,9 +5,18 @@ import { getExternalBrowserLaunchProtocol } from "./getters.js";
  * Launches the user set browser. If the browser is not set, launch the welcome page.
  *
  * @param {*} url The url to launch in the browser.
+ * @param {boolean} usePrivateBrowsing True if the browser should be launched in private browsing mode, false for normal mode.
  * @returns {boolean} True if the browser was launched, false otherwise.
  */
-export async function launchBrowser(url) {
+export async function launchBrowser(url, usePrivateBrowsing = false) {
+  if (usePrivateBrowsing) {
+    // NOTE: an argument of --incognito in the launchApp call would launch the browser in private mode in chromium.
+    console.error(
+      "Private browsing launching is not yet supported from Firefox.",
+    );
+    return false;
+  }
+
   if (isCurrentTabValidUrlScheme) {
     const launchProtocol = await getExternalBrowserLaunchProtocol();
     if (launchProtocol) {

--- a/src/firefox/interfaces/listeners.js
+++ b/src/firefox/interfaces/listeners.js
@@ -6,7 +6,7 @@ import { getExternalBrowser } from "Shared/backgroundScripts/getters.js";
  */
 export function initPlatformListeners() {
   browser.action.onClicked.addListener(async (tab) => {
-    if (await launchBrowser(tab)) {
+    if (await launchBrowser(tab.url)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",

--- a/src/shared/backgroundScripts/contextMenus.js
+++ b/src/shared/backgroundScripts/contextMenus.js
@@ -87,11 +87,11 @@ export async function handleBrowserNameChange() {
  * Handles the context menu item clicks. Redirects to the proper handler.
  *
  * @param {Object} info The context menu item object.
- * @param {string} url The url the context menu will handle.
+ * @param {Object} tab The tab object to launch the browser with.
  */
-export async function handleContextMenuClick(info, url) {
+export async function handleContextMenuClick(info, tab) {
   if (info.menuItemId === "launchInExternalBrowser") {
-    if (await launchBrowser(url)) {
+    if (await launchBrowser(tab.url)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",
@@ -101,7 +101,7 @@ export async function handleContextMenuClick(info, url) {
       });
     }
   } else if (info.menuItemId === "launchInExternalBrowserLink") {
-    if (await launchBrowser(url)) {
+    if (await launchBrowser(info.linkUrl)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",
@@ -115,7 +115,7 @@ export async function handleContextMenuClick(info, url) {
       url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
     });
   } else {
-    await handlePlatformContextMenuClick(info, url);
+    await handlePlatformContextMenuClick(info, tab);
   }
   // } else if (info.menuItemId === "manageExternalSitesContextMenu") {
   //   browser.tabs.create({

--- a/src/shared/backgroundScripts/contextMenus.js
+++ b/src/shared/backgroundScripts/contextMenus.js
@@ -87,11 +87,11 @@ export async function handleBrowserNameChange() {
  * Handles the context menu item clicks. Redirects to the proper handler.
  *
  * @param {Object} info The context menu item object.
- * @param {Object} tab The current tab object.
+ * @param {string} url The url the context menu will handle.
  */
-export async function handleContextMenuClick(info, tab) {
+export async function handleContextMenuClick(info, url) {
   if (info.menuItemId === "launchInExternalBrowser") {
-    if (await launchBrowser(tab)) {
+    if (await launchBrowser(url)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",
@@ -101,8 +101,7 @@ export async function handleContextMenuClick(info, tab) {
       });
     }
   } else if (info.menuItemId === "launchInExternalBrowserLink") {
-    tab.url = info.linkUrl;
-    if (await launchBrowser(tab)) {
+    if (await launchBrowser(url)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",
@@ -116,7 +115,7 @@ export async function handleContextMenuClick(info, tab) {
       url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
     });
   } else {
-    await handlePlatformContextMenuClick(info, tab);
+    await handlePlatformContextMenuClick(info, url);
   }
   // } else if (info.menuItemId === "manageExternalSitesContextMenu") {
   //   browser.tabs.create({

--- a/src/shared/backgroundScripts/contextMenus.js
+++ b/src/shared/backgroundScripts/contextMenus.js
@@ -23,6 +23,7 @@ export async function initContextMenu() {
       defaultLaunchMode,
     ),
     contexts: ["page"],
+    documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
   });
 
   // link context menu
@@ -33,6 +34,7 @@ export async function initContextMenu() {
       defaultLaunchMode,
     ),
     contexts: ["link"],
+    targetUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
   });
 
   const action = browser.action ? "action" : "browser_action"; // mv2 vs mv3

--- a/src/shared/backgroundScripts/hotkeys.js
+++ b/src/shared/backgroundScripts/hotkeys.js
@@ -9,7 +9,7 @@ import { getExternalBrowser } from "./getters.js";
  */
 export async function handleHotkeyPress(command, tab) {
   if (command === "launchBrowser") {
-    if (await launchBrowser(tab)) {
+    if (await launchBrowser(tab.url)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",
@@ -19,7 +19,7 @@ export async function handleHotkeyPress(command, tab) {
       });
     }
   } else if (command === "launchFirefoxPrivate") {
-    if (await launchBrowser(tab, true)) {
+    if (await launchBrowser(tab.url, true)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",

--- a/src/shared/backgroundScripts/listeners.js
+++ b/src/shared/backgroundScripts/listeners.js
@@ -20,8 +20,7 @@ export function initSharedListeners() {
   });
 
   browser.contextMenus.onClicked.addListener(async (info, tab) => {
-    const url = info.linkUrl || tab.url;
-    await handleContextMenuClick(info, url);
+    await handleContextMenuClick(info, tab);
   });
 
   browser.commands.onCommand.addListener(async (command) => {

--- a/src/shared/backgroundScripts/listeners.js
+++ b/src/shared/backgroundScripts/listeners.js
@@ -20,7 +20,8 @@ export function initSharedListeners() {
   });
 
   browser.contextMenus.onClicked.addListener(async (info, tab) => {
-    await handleContextMenuClick(info, tab);
+    const url = info.linkUrl || tab.url;
+    await handleContextMenuClick(info, url);
   });
 
   browser.commands.onCommand.addListener(async (command) => {

--- a/src/shared/backgroundScripts/validTab.js
+++ b/src/shared/backgroundScripts/validTab.js
@@ -19,6 +19,21 @@ export function checkAndUpdateURLScheme(tab) {
 }
 
 /**
+ * Checks if the given url's protocol is one of https:, http:, or file:.
+ *
+ * @param {string} url A url to check the scheme of.
+ * @returns {boolean} True if the url is valid, false otherwise.
+ */
+export function isURLValid(url) {
+  return (
+    url &&
+    (url.startsWith("https:") ||
+      url.startsWith("http:") ||
+      url.startsWith("file:"))
+  );
+}
+
+/**
  * Sets the global variable isCurrentTabValidUrlScheme to the given boolean.
  * For use in tests.
  *

--- a/test/chromium/interfaces/contextMenus.test.js
+++ b/test/chromium/interfaces/contextMenus.test.js
@@ -29,6 +29,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
         id: "launchInExternalBrowserPrivate",
         title: getLocaleMessage("launchInExternalBrowser"),
         contexts: ["page"],
+        documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
       });
     });
   });

--- a/test/chromium/interfaces/launchBrowser.test.js
+++ b/test/chromium/interfaces/launchBrowser.test.js
@@ -1,6 +1,6 @@
 import { launchBrowser } from "../../../src/chromium/interfaces/launchBrowser.js";
 
-import { setStorage } from "../../setup.test.js";
+import { setCurrentTab, setStorage } from "../../setup.test.js";
 import { setIsCurrentTabValidUrlScheme } from "Shared/backgroundScripts/validTab.js";
 
 describe("chromium/interfaces/launchBrowser.js", () => {
@@ -17,9 +17,13 @@ describe("chromium/interfaces/launchBrowser.js", () => {
 
     it("should launch the current tab in Firefox", async () => {
       setStorage("isFirefoxInstalled", true);
+      setCurrentTab({
+        id: 1,
+        url: "https://mozilla.org",
+      });
       setIsCurrentTabValidUrlScheme(true);
       const result = await launchBrowser(
-        { id: 1, url: "https://mozilla.org" },
+         "https://mozilla.org",
         false,
       );
       expect(result).toBeTruthy();
@@ -31,9 +35,13 @@ describe("chromium/interfaces/launchBrowser.js", () => {
 
     it("should launch the current tab in Firefox Private Browsing", async () => {
       setStorage("isFirefoxInstalled", true);
+      setCurrentTab({
+        id: 1,
+        url: "https://mozilla.org",
+      });
       setIsCurrentTabValidUrlScheme(true);
       const result = await launchBrowser(
-        { id: 1, url: "https://mozilla.org" },
+       "https://mozilla.org",
         true,
       );
       expect(result).toBeTruthy();

--- a/test/chromium/interfaces/launchBrowser.test.js
+++ b/test/chromium/interfaces/launchBrowser.test.js
@@ -22,10 +22,7 @@ describe("chromium/interfaces/launchBrowser.js", () => {
         url: "https://mozilla.org",
       });
       setIsCurrentTabValidUrlScheme(true);
-      const result = await launchBrowser(
-         "https://mozilla.org",
-        false,
-      );
+      const result = await launchBrowser("https://mozilla.org", false);
       expect(result).toBeTruthy();
       expect(browser.tabs.update).toHaveBeenCalled();
       expect(browser.tabs.update).toHaveBeenCalledWith(1, {
@@ -40,10 +37,7 @@ describe("chromium/interfaces/launchBrowser.js", () => {
         url: "https://mozilla.org",
       });
       setIsCurrentTabValidUrlScheme(true);
-      const result = await launchBrowser(
-       "https://mozilla.org",
-        true,
-      );
+      const result = await launchBrowser("https://mozilla.org", true);
       expect(result).toBeTruthy();
       expect(browser.tabs.update).toHaveBeenCalled();
       expect(browser.tabs.update).toHaveBeenCalledWith(1, {

--- a/test/chromium/interfaces/launchBrowser.test.js
+++ b/test/chromium/interfaces/launchBrowser.test.js
@@ -1,13 +1,12 @@
 import { launchBrowser } from "../../../src/chromium/interfaces/launchBrowser.js";
-
 import { setCurrentTab, setStorage } from "../../setup.test.js";
-import { setIsCurrentTabValidUrlScheme } from "Shared/backgroundScripts/validTab.js";
+import jest from "jest-mock";
 
 describe("chromium/interfaces/launchBrowser.js", () => {
   describe("launchBrowser()", () => {
     it("should direct the user to the Firefox download page if Firefox is not installed", async () => {
       setStorage("isFirefoxInstalled", false);
-      const result = await launchBrowser();
+      const result = await launchBrowser("https://example.com", false);
       expect(result).toBeFalsy();
       expect(browser.tabs.create).toHaveBeenCalled();
       expect(browser.tabs.create).toHaveBeenCalledWith({
@@ -21,7 +20,6 @@ describe("chromium/interfaces/launchBrowser.js", () => {
         id: 1,
         url: "https://mozilla.org",
       });
-      setIsCurrentTabValidUrlScheme(true);
       const result = await launchBrowser("https://mozilla.org", false);
       expect(result).toBeTruthy();
       expect(browser.tabs.update).toHaveBeenCalled();
@@ -36,7 +34,6 @@ describe("chromium/interfaces/launchBrowser.js", () => {
         id: 1,
         url: "https://mozilla.org",
       });
-      setIsCurrentTabValidUrlScheme(true);
       const result = await launchBrowser("https://mozilla.org", true);
       expect(result).toBeTruthy();
       expect(browser.tabs.update).toHaveBeenCalled();
@@ -47,14 +44,13 @@ describe("chromium/interfaces/launchBrowser.js", () => {
 
     it("should not launch the current tab if the url scheme is not valid", async () => {
       setStorage("isFirefoxInstalled", true);
-      setIsCurrentTabValidUrlScheme(false);
-      const result = await launchBrowser(
-        { id: 1, url: "https://mozilla.org" },
-        true,
-      );
+      console.error = jest.fn();
+      const result = await launchBrowser("invalid-url://mozilla.org", true);
       expect(result).toBeFalsy();
+      expect(console.error).toHaveBeenCalled();
       expect(browser.tabs.create).not.toHaveBeenCalled();
       expect(browser.tabs.update).not.toHaveBeenCalled();
+      console.error.mockRestore();
     });
   });
 });

--- a/test/firefox/interfaces/launchBrowser.test.js
+++ b/test/firefox/interfaces/launchBrowser.test.js
@@ -1,18 +1,15 @@
 import { launchBrowser } from "../../../src/firefox/interfaces/launchBrowser.js";
-import { setIsCurrentTabValidUrlScheme } from "Shared/backgroundScripts/validTab.js";
 import { setStorage } from "../../setup.test.js";
 import jest from "jest-mock";
 
 describe("firefox/interfaces/launchBrowser.js", () => {
   describe("launchBrowser()", () => {
     it("should return false if the url scheme is not valid", async () => {
-      setIsCurrentTabValidUrlScheme(false);
       const result = await launchBrowser("https://example.com");
       expect(result).toEqual(false);
     });
 
     it("should return false and open the welcome page if there is no launch protocol", async () => {
-      setIsCurrentTabValidUrlScheme(true);
       const result = await launchBrowser("https://example.com");
       expect(result).toEqual(false);
       expect(browser.tabs.create).toHaveBeenCalled();
@@ -22,7 +19,6 @@ describe("firefox/interfaces/launchBrowser.js", () => {
     });
 
     it("should return true if there is a launch protocol", async () => {
-      setIsCurrentTabValidUrlScheme(true);
       setStorage("currentExternalBrowserLaunchProtocol", "test");
       const result = await launchBrowser("https://example.com");
       expect(result).toEqual(true);
@@ -34,11 +30,11 @@ describe("firefox/interfaces/launchBrowser.js", () => {
     });
 
     it("should return false if the browser is launched in private mode", async () => {
-      setIsCurrentTabValidUrlScheme(true);
       console.error = jest.fn();
       const result = await launchBrowser("https://example.com", true);
       expect(result).toEqual(false);
       expect(console.error).toHaveBeenCalled();
+      console.error.mockRestore();
     });
   });
 });

--- a/test/firefox/interfaces/launchBrowser.test.js
+++ b/test/firefox/interfaces/launchBrowser.test.js
@@ -1,6 +1,7 @@
 import { launchBrowser } from "../../../src/firefox/interfaces/launchBrowser.js";
 import { setIsCurrentTabValidUrlScheme } from "Shared/backgroundScripts/validTab.js";
 import { setStorage } from "../../setup.test.js";
+import jest from "jest-mock";
 
 describe("firefox/interfaces/launchBrowser.js", () => {
   describe("launchBrowser()", () => {
@@ -30,6 +31,14 @@ describe("firefox/interfaces/launchBrowser.js", () => {
         "test",
         ["https://example.com"],
       );
+    });
+
+    it("should return false if the browser is launched in private mode", async () => {
+      setIsCurrentTabValidUrlScheme(true);
+      console.error = jest.fn();
+      const result = await launchBrowser("https://example.com", true);
+      expect(result).toEqual(false);
+      expect(console.error).toHaveBeenCalled();
     });
   });
 });

--- a/test/firefox/interfaces/launchBrowser.test.js
+++ b/test/firefox/interfaces/launchBrowser.test.js
@@ -5,8 +5,11 @@ import jest from "jest-mock";
 describe("firefox/interfaces/launchBrowser.js", () => {
   describe("launchBrowser()", () => {
     it("should return false if the url scheme is not valid", async () => {
-      const result = await launchBrowser("https://example.com");
+      console.error = jest.fn();
+      const result = await launchBrowser("fake://example.com");
       expect(result).toEqual(false);
+      expect(console.error).toHaveBeenCalled();
+      console.error.mockRestore();
     });
 
     it("should return false and open the welcome page if there is no launch protocol", async () => {

--- a/test/firefox/interfaces/launchBrowser.test.js
+++ b/test/firefox/interfaces/launchBrowser.test.js
@@ -6,13 +6,13 @@ describe("firefox/interfaces/launchBrowser.js", () => {
   describe("launchBrowser()", () => {
     it("should return false if the url scheme is not valid", async () => {
       setIsCurrentTabValidUrlScheme(false);
-      const result = await launchBrowser({ url: "https://example.com" });
+      const result = await launchBrowser("https://example.com");
       expect(result).toEqual(false);
     });
 
     it("should return false and open the welcome page if there is no launch protocol", async () => {
       setIsCurrentTabValidUrlScheme(true);
-      const result = await launchBrowser({ url: "https://example.com" });
+      const result = await launchBrowser("https://example.com");
       expect(result).toEqual(false);
       expect(browser.tabs.create).toHaveBeenCalled();
       expect(browser.tabs.create).toHaveBeenCalledWith({
@@ -23,7 +23,7 @@ describe("firefox/interfaces/launchBrowser.js", () => {
     it("should return true if there is a launch protocol", async () => {
       setIsCurrentTabValidUrlScheme(true);
       setStorage("currentExternalBrowserLaunchProtocol", "test");
-      const result = await launchBrowser({ url: "https://example.com" });
+      const result = await launchBrowser("https://example.com");
       expect(result).toEqual(true);
       expect(browser.experiments.firefox_launch.launchApp).toHaveBeenCalled();
       expect(browser.experiments.firefox_launch.launchApp).toHaveBeenCalledWith(

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -134,14 +134,12 @@ export const setExtensionPlatform = (platform) => {
   global.IS_CHROME_EXTENSION = platform === "chromium";
 };
 
-export const setCurrentTabURL = (currentTabURL) => {
+export const setCurrentTab = (tabObject) => {
   const browserTabsQueryMock = jest.spyOn(global.browser.tabs, "query");
   browserTabsQueryMock.mockImplementation(() => {
     return new Promise((resolve) => {
       resolve([
-        {
-          url: currentTabURL,
-        },
+        tabObject
       ]);
     });
   });

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -138,9 +138,7 @@ export const setCurrentTab = (tabObject) => {
   const browserTabsQueryMock = jest.spyOn(global.browser.tabs, "query");
   browserTabsQueryMock.mockImplementation(() => {
     return new Promise((resolve) => {
-      resolve([
-        tabObject
-      ]);
+      resolve([tabObject]);
     });
   });
 };

--- a/test/shared/backgroundScripts/contextMenus.test.js
+++ b/test/shared/backgroundScripts/contextMenus.test.js
@@ -16,11 +16,13 @@ describe("shared/backgroundScripts/contextMenus.js", () => {
         id: "launchInExternalBrowser",
         title: getLocaleMessage("launchInExternalBrowser"),
         contexts: ["page"],
+        documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
       });
       expect(browser.contextMenus.create).toHaveBeenCalledWith({
         id: "launchInExternalBrowserLink",
         title: getLocaleMessage("launchInExternalBrowserLink"),
         contexts: ["link"],
+        targetUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
       });
       expect(browser.contextMenus.create).toHaveBeenCalledWith({
         id: "openWelcomePage",


### PR DESCRIPTION
This patch changes launchBrowser and its callers to use url as a parameter instead of tab and retrieve the current tab ID in the function itself.

The calls to launchBrowser and telemetry in the context menu handler functions are quite repetitive. Since the url parameter doesn't change, it might be worth condensing them.

Code Review comments:
- https://github.com/mozilla/firefox-launch/pull/18/files#r1468904714
- https://github.com/mozilla/firefox-launch/pull/18/files#r1468671493