### PR TITLE
Code Review: isFirefoxInstalled context + tests

### DIFF
--- a/src/chromium/interfaces/getters.js
+++ b/src/chromium/interfaces/getters.js
@@ -6,10 +6,11 @@ import { getExternalBrowser } from "Shared/backgroundScripts/getters.js";
  * @returns {Promise<boolean>} True if Firefox is installed on the system, false otherwise.
  */
 export async function getIsFirefoxInstalled() {
-  const result = await browser.storage.local.get("isFirefoxInstalled");
+  // NOTE: We are not currently handling the case where Firefox is not installed until
+  // native messaging is implemented. We will assume for now that Firefox is always installed.
+  const result = await browser.storage.session.get("isFirefoxInstalled");
   if (result.isFirefoxInstalled === undefined) {
-    // placeholder
-    browser.storage.local.set({ isFirefoxInstalled: true });
+    browser.storage.session.set({ isFirefoxInstalled: true });
     return true;
   }
   return result.isFirefoxInstalled;

--- a/test/chromium/interfaces/contextMenus.test.js
+++ b/test/chromium/interfaces/contextMenus.test.js
@@ -6,8 +6,8 @@ import {
 import { setStorage, getLocaleMessage } from "../../setup.test.js";
 
 describe("chromium/interfaces/contextMenus.js", () => {
-  beforeEach(() => {
-    setStorage("currentExternalBrowser", "Firefox");
+  beforeEach(async () => {
+    await setStorage("currentExternalBrowser", "Firefox");
   });
   describe("applyPlatformContextMenus()", () => {
     it("should create the chrome context menu", async () => {
@@ -51,7 +51,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
     });
 
     it("should swap the alternative launch mode and set the currentExternalBrowser to Firefox", async () => {
-      setStorage("currentExternalBrowser", "Firefox Private Browsing");
+      await setStorage("currentExternalBrowser", "Firefox Private Browsing");
       await handleChangeDefaultLaunchContextMenuClick({
         checked: false,
       });

--- a/test/chromium/interfaces/getters.test.js
+++ b/test/chromium/interfaces/getters.test.js
@@ -9,13 +9,13 @@ import { setStorage } from "../../setup.test.js";
 describe("chromium/interfaces/getters.js", () => {
   describe("getIsFirefoxInstalled()", () => {
     it("should return true if a Firefox browser is installed", async () => {
-      setStorage("isFirefoxInstalled", true);
+      await setStorage("isFirefoxInstalled", true);
       const result = await getIsFirefoxInstalled();
       expect(result).toBeTruthy();
     });
 
     it("should return false if a Firefox browser is not installed", async () => {
-      setStorage("isFirefoxInstalled", false);
+      await setStorage("isFirefoxInstalled", false);
       const result = await getIsFirefoxInstalled();
       expect(result).toBeFalsy();
     });
@@ -23,7 +23,7 @@ describe("chromium/interfaces/getters.js", () => {
 
   describe("getDefaultIconPath()", () => {
     it("should return the firefox icon path", async () => {
-      setStorage("currentExternalBrowser", "Firefox");
+      await setStorage("currentExternalBrowser", "Firefox");
       const result = await getDefaultIconPath();
       expect(result).toStrictEqual({
         32: browser.runtime.getURL("images/firefox/firefox32.png"),
@@ -31,7 +31,7 @@ describe("chromium/interfaces/getters.js", () => {
     });
 
     it("should return the firefox private icon path", async () => {
-      setStorage("currentExternalBrowser", "Firefox Private Browsing");
+      await setStorage("currentExternalBrowser", "Firefox Private Browsing");
       const result = await getDefaultIconPath();
       expect(result).toStrictEqual({
         32: browser.runtime.getURL("images/firefox-private/private32.png"),
@@ -41,7 +41,7 @@ describe("chromium/interfaces/getters.js", () => {
 
   describe("getGreyedIconPath()", () => {
     it("should return the greyed firefox icon path", async () => {
-      setStorage("currentExternalBrowser", "Firefox");
+      await setStorage("currentExternalBrowser", "Firefox");
       const result = await getGreyedIconPath();
       expect(result).toStrictEqual({
         32: browser.runtime.getURL("images/firefox/firefox32grey.png"),
@@ -49,7 +49,7 @@ describe("chromium/interfaces/getters.js", () => {
     });
 
     it("should return the greyed firefox private icon path", async () => {
-      setStorage("currentExternalBrowser", "Firefox Private Browsing");
+      await setStorage("currentExternalBrowser", "Firefox Private Browsing");
       const result = await getGreyedIconPath();
       expect(result).toStrictEqual({
         32: browser.runtime.getURL("images/firefox-private/private32grey.png"),

--- a/test/chromium/interfaces/launchBrowser.test.js
+++ b/test/chromium/interfaces/launchBrowser.test.js
@@ -6,7 +6,7 @@ import { setIsCurrentTabValidUrlScheme } from "Shared/backgroundScripts/validTab
 describe("chromium/interfaces/launchBrowser.js", () => {
   describe("launchBrowser()", () => {
     it("should direct the user to the Firefox download page if Firefox is not installed", async () => {
-      setStorage("isFirefoxInstalled", false);
+      await setStorage("isFirefoxInstalled", false);
       const result = await launchBrowser();
       expect(result).toBeFalsy();
       expect(browser.tabs.create).toHaveBeenCalled();
@@ -16,7 +16,7 @@ describe("chromium/interfaces/launchBrowser.js", () => {
     });
 
     it("should launch the current tab in Firefox", async () => {
-      setStorage("isFirefoxInstalled", true);
+      await setStorage("isFirefoxInstalled", true);
       setIsCurrentTabValidUrlScheme(true);
       const result = await launchBrowser(
         { id: 1, url: "https://mozilla.org" },
@@ -30,7 +30,7 @@ describe("chromium/interfaces/launchBrowser.js", () => {
     });
 
     it("should launch the current tab in Firefox Private Browsing", async () => {
-      setStorage("isFirefoxInstalled", true);
+      await setStorage("isFirefoxInstalled", true);
       setIsCurrentTabValidUrlScheme(true);
       const result = await launchBrowser(
         { id: 1, url: "https://mozilla.org" },
@@ -44,7 +44,7 @@ describe("chromium/interfaces/launchBrowser.js", () => {
     });
 
     it("should not launch the current tab if the url scheme is not valid", async () => {
-      setStorage("isFirefoxInstalled", true);
+      await setStorage("isFirefoxInstalled", true);
       setIsCurrentTabValidUrlScheme(false);
       const result = await launchBrowser(
         { id: 1, url: "https://mozilla.org" },

--- a/test/chromium/interfaces/listeners.test.js
+++ b/test/chromium/interfaces/listeners.test.js
@@ -3,8 +3,8 @@ import { initPlatformListeners } from "../../../src/chromium/interfaces/listener
 import { setStorage } from "../../setup.test.js";
 
 describe("chromium/interfaces/listeners.js", () => {
-  beforeEach(() => {
-    setStorage("currentExternalBrowser", "Firefox");
+  beforeEach(async () => {
+    await setStorage("currentExternalBrowser", "Firefox");
   });
   describe("initPlatformListeners()", () => {
     it("should add the listeners", () => {

--- a/test/firefox/interfaces/contextMenus.test.js
+++ b/test/firefox/interfaces/contextMenus.test.js
@@ -3,8 +3,8 @@ import { handlePlatformContextMenuClick } from "../../../src/firefox/interfaces/
 import { setStorage } from "../../setup.test.js";
 
 describe("firefox/interfaces/contextMenus.js", () => {
-  beforeEach(() => {
-    setStorage("currentExternalBrowser", "Firefox");
+  beforeEach(async () => {
+    await setStorage("currentExternalBrowser", "Firefox");
   });
   describe("applyPlatformContextMenus()", () => {});
 

--- a/test/firefox/interfaces/getters.test.js
+++ b/test/firefox/interfaces/getters.test.js
@@ -8,7 +8,7 @@ import { setStorage } from "../../setup.test.js";
 describe("firefox/interfaces/getters.js", () => {
   describe("getDefaultIconPath()", () => {
     it("should return the current browser icon path", async () => {
-      setStorage("currentExternalBrowser", "chrome");
+      await setStorage("currentExternalBrowser", "chrome");
       const result = await getDefaultIconPath();
       expect(result).toStrictEqual({
         32: browser.runtime.getURL("images/chrome/32.png"),
@@ -16,7 +16,7 @@ describe("firefox/interfaces/getters.js", () => {
     });
 
     it("should return the firefox icon if no current browser", async () => {
-      setStorage("currentExternalBrowser", undefined);
+      await setStorage("currentExternalBrowser", undefined);
       const result = await getDefaultIconPath();
       expect(result).toStrictEqual({
         32: browser.runtime.getURL("images/firefox-launch/32.png"),
@@ -26,7 +26,7 @@ describe("firefox/interfaces/getters.js", () => {
 
   describe("getGreyedIconPath()", () => {
     it("should return the greyed current browser icon path", async () => {
-      setStorage("currentExternalBrowser", "chrome");
+      await setStorage("currentExternalBrowser", "chrome");
       const result = await getGreyedIconPath();
       expect(result).toStrictEqual({
         32: browser.runtime.getURL("images/chrome/32grey.png"),
@@ -34,7 +34,7 @@ describe("firefox/interfaces/getters.js", () => {
     });
 
     it("should return firefox icon if no current browser", async () => {
-      setStorage("currentExternalBrowser", undefined);
+      await setStorage("currentExternalBrowser", undefined);
       const result = await getGreyedIconPath();
       expect(result).toStrictEqual({
         32: browser.runtime.getURL("images/firefox-launch/32.png"),
@@ -44,13 +44,13 @@ describe("firefox/interfaces/getters.js", () => {
 
   describe("getExternalBrowserLaunchProtocol()", () => {
     it("should return the current external browser launch protocol", async () => {
-      setStorage("currentExternalBrowserLaunchProtocol", "test");
+      await setStorage("currentExternalBrowserLaunchProtocol", "test");
       const result = await getExternalBrowserLaunchProtocol();
       expect(result).toEqual("test");
     });
 
     it("should return an empty string if no current external browser launch protocol", async () => {
-      setStorage("currentExternalBrowserLaunchProtocol", undefined);
+      await setStorage("currentExternalBrowserLaunchProtocol", undefined);
       const result = await getExternalBrowserLaunchProtocol();
       expect(result).toEqual("");
     });

--- a/test/firefox/interfaces/launchBrowser.test.js
+++ b/test/firefox/interfaces/launchBrowser.test.js
@@ -12,7 +12,7 @@ describe("firefox/interfaces/launchBrowser.js", () => {
 
     it("should return false and open the welcome page if there is no launch protocol", async () => {
       setIsCurrentTabValidUrlScheme(true);
-      setStorage("currentExternalBrowserLaunchProtocol", "");
+      await setStorage("currentExternalBrowserLaunchProtocol", "");
       const result = await launchBrowser({ url: "https://example.com" });
       expect(result).toEqual(false);
       expect(browser.tabs.create).toHaveBeenCalled();
@@ -23,7 +23,7 @@ describe("firefox/interfaces/launchBrowser.js", () => {
 
     it("should return true if there is a launch protocol", async () => {
       setIsCurrentTabValidUrlScheme(true);
-      setStorage("currentExternalBrowserLaunchProtocol", "test");
+      await setStorage("currentExternalBrowserLaunchProtocol", "test");
       const result = await launchBrowser({ url: "https://example.com" });
       expect(result).toEqual(true);
       expect(browser.experiments.firefox_launch.launchApp).toHaveBeenCalled();

--- a/test/firefox/interfaces/launchBrowser.test.js
+++ b/test/firefox/interfaces/launchBrowser.test.js
@@ -12,6 +12,7 @@ describe("firefox/interfaces/launchBrowser.js", () => {
 
     it("should return false and open the welcome page if there is no launch protocol", async () => {
       setIsCurrentTabValidUrlScheme(true);
+      setStorage("currentExternalBrowserLaunchProtocol", "");
       const result = await launchBrowser({ url: "https://example.com" });
       expect(result).toEqual(false);
       expect(browser.tabs.create).toHaveBeenCalled();

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -112,7 +112,7 @@ global.document = {
 export const setSyncStorage = async (key, keyValue) => {
   let data = {};
   if (global.browser.storage.sync.get.mock) {
-    data = await global.browser.storage.sync.get() || {};
+    data = (await global.browser.storage.sync.get()) || {};
   }
   data[key] = keyValue;
   jest.spyOn(global.browser.storage.sync, "get").mockImplementation(() => {
@@ -125,7 +125,7 @@ export const setSyncStorage = async (key, keyValue) => {
 export const setLocalStorage = async (key, keyValue) => {
   let data = {};
   if (global.browser.storage.local.get.mock) {
-    data = await global.browser.storage.local.get() || {};
+    data = (await global.browser.storage.local.get()) || {};
   }
   data[key] = keyValue;
   jest.spyOn(global.browser.storage.local, "get").mockImplementation(() => {
@@ -138,7 +138,7 @@ export const setLocalStorage = async (key, keyValue) => {
 export const setSessionStorage = async (key, keyValue) => {
   let data = {};
   if (global.browser.storage.session.get.mock) {
-    data = await global.browser.storage.session.get() || {};
+    data = (await global.browser.storage.session.get()) || {};
   }
   data[key] = keyValue;
   jest.spyOn(global.browser.storage.session, "get").mockImplementation(() => {

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -147,17 +147,17 @@ export const setSessionStorage = async (key, keyValue) => {
     });
   });
 };
-export const setStorage = (key, keyValue, storageLocation) => {
+export const setStorage = async (key, keyValue, storageLocation) => {
   if (storageLocation === "sync") {
-    setSyncStorage(key, keyValue);
+    await setSyncStorage(key, keyValue);
   } else if (storageLocation === "local") {
-    setLocalStorage(key, keyValue);
+    await setLocalStorage(key, keyValue);
   } else if (storageLocation === "session") {
-    setSessionStorage(key, keyValue);
+    await setSessionStorage(key, keyValue);
   } else {
-    setSyncStorage(key, keyValue);
-    setLocalStorage(key, keyValue);
-    setSessionStorage(key, keyValue);
+    await setSyncStorage(key, keyValue);
+    await setLocalStorage(key, keyValue);
+    await setSessionStorage(key, keyValue);
   }
 };
 
@@ -204,7 +204,7 @@ jest.spyOn(global.browser.i18n, "getMessage").mockImplementation((key) => {
 
 beforeEach(async () => {
   await testResetGlean("firefox-launch");
-  setStorage("isFirefoxInstalled", true, "session");
+  await setStorage("isFirefoxInstalled", true, "session");
 });
 
 afterEach(() => {

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -31,6 +31,13 @@ global.browser = {
         addListener: jest.fn(),
       },
     },
+    session: {
+      get: jest.fn(),
+      set: jest.fn(),
+      onChanged: {
+        addListener: jest.fn(),
+      },
+    },
     onChanged: {
       addListener: jest.fn(),
     },
@@ -102,30 +109,55 @@ global.document = {
   addEventListener: jest.fn(),
 };
 
-export const setSyncStorage = (key, keyValue) => {
+export const setSyncStorage = async (key, keyValue) => {
+  let data = {};
+  if (global.browser.storage.sync.get.mock) {
+    data = await global.browser.storage.sync.get() || {};
+  }
+  data[key] = keyValue;
   jest.spyOn(global.browser.storage.sync, "get").mockImplementation(() => {
     return new Promise((resolve) => {
-      resolve({ [key]: keyValue });
+      resolve(data);
     });
   });
 };
 
-export const setLocalStorage = (key, keyValue) => {
+export const setLocalStorage = async (key, keyValue) => {
+  let data = {};
+  if (global.browser.storage.local.get.mock) {
+    data = await global.browser.storage.local.get() || {};
+  }
+  data[key] = keyValue;
   jest.spyOn(global.browser.storage.local, "get").mockImplementation(() => {
     return new Promise((resolve) => {
-      resolve({ [key]: keyValue });
+      resolve(data);
     });
   });
 };
 
+export const setSessionStorage = async (key, keyValue) => {
+  let data = {};
+  if (global.browser.storage.session.get.mock) {
+    data = await global.browser.storage.session.get() || {};
+  }
+  data[key] = keyValue;
+  jest.spyOn(global.browser.storage.session, "get").mockImplementation(() => {
+    return new Promise((resolve) => {
+      resolve(data);
+    });
+  });
+};
 export const setStorage = (key, keyValue, storageLocation) => {
   if (storageLocation === "sync") {
     setSyncStorage(key, keyValue);
   } else if (storageLocation === "local") {
     setLocalStorage(key, keyValue);
+  } else if (storageLocation === "session") {
+    setSessionStorage(key, keyValue);
   } else {
     setSyncStorage(key, keyValue);
     setLocalStorage(key, keyValue);
+    setSessionStorage(key, keyValue);
   }
 };
 
@@ -172,7 +204,7 @@ jest.spyOn(global.browser.i18n, "getMessage").mockImplementation((key) => {
 
 beforeEach(async () => {
   await testResetGlean("firefox-launch");
-  setStorage("isFirefoxInstalled", true);
+  setStorage("isFirefoxInstalled", true, "session");
 });
 
 afterEach(() => {

--- a/test/shared/backgroundScripts/actionButton.test.js
+++ b/test/shared/backgroundScripts/actionButton.test.js
@@ -7,7 +7,7 @@ import { setIsCurrentTabValidUrlScheme } from "Shared/backgroundScripts/validTab
 describe("shared/backgroundScripts/actionButton.js", () => {
   describe("updateToolbarIcon()", () => {
     it("should set the toolbar icon to the default icon path", async () => {
-      setStorage("currentExternalBrowser", "Firefox");
+      await setStorage("currentExternalBrowser", "Firefox");
       await updateToolbarIcon();
       expect(browser.action.setIcon).toHaveBeenCalled();
       expect(browser.action.setIcon).toHaveBeenCalledWith({
@@ -16,7 +16,7 @@ describe("shared/backgroundScripts/actionButton.js", () => {
     });
 
     it("should set the toolbar icon to the greyed icon path", async () => {
-      setStorage("currentExternalBrowser", "Firefox");
+      await setStorage("currentExternalBrowser", "Firefox");
       setIsCurrentTabValidUrlScheme(false);
       await updateToolbarIcon();
       expect(browser.action.setIcon).toHaveBeenCalled();

--- a/test/shared/backgroundScripts/contextMenus.test.js
+++ b/test/shared/backgroundScripts/contextMenus.test.js
@@ -9,7 +9,7 @@ import {
 describe("shared/backgroundScripts/contextMenus.js", () => {
   describe("initContextMenu()", () => {
     it("should make the shared context menu", async () => {
-      setStorage("currentExternalBrowser", "Firefox");
+      await setStorage("currentExternalBrowser", "Firefox");
       setExtensionPlatform("chromium");
       await initContextMenu();
       expect(browser.contextMenus.create).toHaveBeenCalledWith({


### PR DESCRIPTION
Update the isFirefoxInstalled getter to be clear why it is always true and to use session storage. Update tests to support this change, including having a better storage mocking system.

Code Review comments:
- https://github.com/mozilla/firefox-launch/pull/18/files#r1468671709