### PR TITLE
Code Review: telemetry pings no longer use storage api

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -4,8 +4,6 @@ install_event:
   date_installed:
     type: datetime
     lifetime: ping
-    send_in_pings:
-      - install
     description: |
       The date and time the extension was installed and launched for the first time
     bugs:
@@ -18,8 +16,6 @@ install_event:
   browser_type:
     type: string
     lifetime: ping
-    send_in_pings:
-      - install
     description: |
       The name of the browser the extension is running on
     bugs:
@@ -33,8 +29,6 @@ startup_event:
   date_started:
     type: datetime
     lifetime: ping
-    send_in_pings:
-      - startup
     description: |
       The date and time the extension was started up
     bugs:
@@ -47,8 +41,6 @@ startup_event:
   browser_type:
     type: string
     lifetime: ping
-    send_in_pings:
-      - startup
     description: |
       The name of the browser the extension is running on
     bugs:
@@ -61,8 +53,6 @@ startup_event:
   browser_language_locale:
     type: string
     lifetime: ping
-    send_in_pings:
-      - startup
     description: |
       The user's preferred language of the browser
     bugs:
@@ -75,8 +65,6 @@ startup_event:
   extension_language_locale:
     type: string
     lifetime: ping
-    send_in_pings:
-      - startup
     description: |
       The language of the extension
     bugs:
@@ -89,8 +77,6 @@ startup_event:
   is_pinned:
     type: boolean
     lifetime: ping
-    send_in_pings:
-      - startup
     description: |
       Whether or not the action button is pinned to the toolbar
     bugs:
@@ -103,8 +89,6 @@ startup_event:
   hotkeys:
     type: labeled_string
     lifetime: ping
-    send_in_pings:
-      - startup
     description: |
       Which hotkeys are set for each command
     bugs:
@@ -118,8 +102,6 @@ launch_event:
   browser_launch:
     type: event
     lifetime: ping
-    send_in_pings:
-      - launch
     description: |
       The user launched the browser from the action button
     bugs:
@@ -140,8 +122,6 @@ setting_event:
   current_browser:
     type: labeled_string
     lifetime: ping
-    send_in_pings:
-      - settings
     description: The external browser has been changed
     bugs:
       - https://linktobugs.page

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -128,7 +128,7 @@ setting_event:
     data_reviews:
       - https://linktodatareviews.page
     notification_emails:
-      - gsherman@mozilla.co
+      - gsherman@mozilla.com
     extra_keys:
       from:
         description: The previously set browser

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -120,7 +120,7 @@ launch_event:
         type: string
 setting_event:
   current_browser:
-    type: labeled_string
+    type: event
     lifetime: ping
     description: The external browser has been changed
     bugs:
@@ -128,7 +128,17 @@ setting_event:
     data_reviews:
       - https://linktodatareviews.page
     notification_emails:
-      - gsherman@mozilla.com
+      - gsherman@mozilla.co
+    extra_keys:
+      from:
+        description: The previously set browser
+        type: string
+      to:
+        description: The newly set external browser
+        type: string
+      source:
+        description: The location that this setting was changed from
+        type: string
     expires: never
 
 

--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -114,13 +114,14 @@ export async function handlePlatformContextMenuClick(info, tab) {
 
   if (info.menuItemId === "changeDefaultLaunchContextMenu") {
     await handleChangeDefaultLaunchContextMenuClick();
-    settingEvent.currentBrowser.from.set(externalBrowserName);
-    settingEvent.currentBrowser.to.set(
-      externalBrowserName === "Firefox"
-        ? "Firefox Private Browsing"
-        : "Firefox",
-    );
-    settingEvent.currentBrowser.source.set("action_context_menu");
+    settingEvent.currentBrowser.record({
+      from: externalBrowserName,
+      to:
+        externalBrowserName === "Firefox"
+          ? "Firefox Private Browsing"
+          : "Firefox",
+      source: "action_context_menu",
+    });
   } else if (info.menuItemId === "alternativeLaunchContextMenu") {
     // launch in the opposite mode to the default
     if (await launchBrowser(tab, externalBrowserName === "Firefox")) {

--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -6,7 +6,6 @@ import * as settingEvent from "Shared/generated/settingEvent.js";
 import * as launchEvent from "Shared/generated/launchEvent.js";
 import { handleDuplicateIDError } from "Shared/backgroundScripts/contextMenus.js";
 
-
 /**
  * Initialize the chromium specific context menu items.
  */

--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -2,6 +2,8 @@ import { launchBrowser } from "./launchBrowser.js";
 
 import { updateToolbarIcon } from "Shared/backgroundScripts/actionButton.js";
 import { getExternalBrowser } from "Shared/backgroundScripts/getters.js";
+import * as settingEvent from "Shared/generated/settingEvent.js";
+import * as launchEvent from "Shared/generated/launchEvent.js";
 
 /**
  * Initialize the chromium specific context menu items.
@@ -112,17 +114,13 @@ export async function handlePlatformContextMenuClick(info, tab) {
 
   if (info.menuItemId === "changeDefaultLaunchContextMenu") {
     await handleChangeDefaultLaunchContextMenuClick();
-    browser.storage.local.set({
-      telemetry: {
-        type: "currentBrowserChange",
-        from: externalBrowserName,
-        to:
-          externalBrowserName === "Firefox"
-            ? "Firefox Private Browsing"
-            : "Firefox",
-        source: "action_context_menu",
-      },
-    });
+    settingEvent.currentBrowser.from.set(externalBrowserName);
+    settingEvent.currentBrowser.to.set(
+      externalBrowserName === "Firefox"
+        ? "Firefox Private Browsing"
+        : "Firefox",
+    );
+    settingEvent.currentBrowser.source.set("action_context_menu");
   } else if (info.menuItemId === "alternativeLaunchContextMenu") {
     // launch in the opposite mode to the default
     if (await launchBrowser(tab, externalBrowserName === "Firefox")) {
@@ -130,33 +128,24 @@ export async function handlePlatformContextMenuClick(info, tab) {
         (await getExternalBrowser()) === "Firefox"
           ? "Firefox Private Browsing"
           : "Firefox";
-      browser.storage.local.set({
-        telemetry: {
-          type: "browserLaunch",
-          browser: launchedBrowserName,
-          source: "action_context_menu",
-        },
+      launchEvent.browserLaunch.record({
+        browser: launchedBrowserName,
+        source: "action_context_menu",
       });
     }
   } else if (info.menuItemId === "launchInExternalBrowserPrivate") {
     if (await launchBrowser(tab, true)) {
-      browser.storage.local.set({
-        telemetry: {
-          type: "browserLaunch",
-          browser: "Firefox Private Browsing",
-          source: "page_context_menu",
-        },
+      launchEvent.browserLaunch.record({
+        browser: "Firefox Private Browsing",
+        source: "page_context_menu",
       });
     }
   } else if (info.menuItemId === "launchInExternalBrowserPrivateLink") {
     tab.url = info.linkUrl;
     if (await launchBrowser(tab, true)) {
-      browser.storage.local.set({
-        telemetry: {
-          type: "browserLaunch",
-          browser: "Firefox Private Browsing",
-          source: "link_context_menu",
-        },
+      launchEvent.browserLaunch.record({
+        browser: "Firefox Private Browsing",
+        source: "link_context_menu",
       });
     }
   }

--- a/src/chromium/interfaces/listeners.js
+++ b/src/chromium/interfaces/listeners.js
@@ -1,6 +1,7 @@
 import { launchBrowser } from "./launchBrowser.js";
 import { getIsFirefoxInstalled } from "./getters.js";
 import { getExternalBrowser } from "Shared/backgroundScripts/getters.js";
+import * as launchEvent from "Shared/generated/launchEvent.js";
 
 /**
  * Initialize the chromium specific listeners.
@@ -10,12 +11,9 @@ export function initPlatformListeners() {
     const browserName = await getExternalBrowser();
     const success = launchBrowser(tab, browserName !== "Firefox");
     if (success) {
-      browser.storage.local.set({
-        telemetry: {
-          type: "browserLaunch",
-          browser: await getExternalBrowser(),
-          source: "action_button",
-        },
+      launchEvent.browserLaunch.record({
+        browser: await getExternalBrowser(),
+        source: "action_button",
       });
     }
   });

--- a/src/firefox/interfaces/listeners.js
+++ b/src/firefox/interfaces/listeners.js
@@ -1,5 +1,6 @@
 import { launchBrowser } from "./launchBrowser.js";
 import { getExternalBrowser } from "Shared/backgroundScripts/getters.js";
+import * as launchEvent from "Shared/generated/launchEvent.js";
 
 /**
  * Initialize the firefox specific listeners.
@@ -7,12 +8,9 @@ import { getExternalBrowser } from "Shared/backgroundScripts/getters.js";
 export function initPlatformListeners() {
   browser.action.onClicked.addListener(async (tab) => {
     if (await launchBrowser(tab)) {
-      browser.storage.local.set({
-        telemetry: {
-          type: "browserLaunch",
-          browser: await getExternalBrowser(),
-          source: "action_button",
-        },
+      launchEvent.browserLaunch.record({
+        browser: await getExternalBrowser(),
+        source: "action_button",
       });
     }
   });

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -12,7 +12,8 @@
   ],
   "background": {
     "scripts": ["background.bundle.js"],
-    "type": "module"
+    "type": "module",
+    "persistent": false
   },
   "browser_action": {
     "default_icon": {

--- a/src/shared/backgroundScripts/contextMenus.js
+++ b/src/shared/backgroundScripts/contextMenus.js
@@ -1,5 +1,6 @@
 import { launchBrowser } from "Interfaces/launchBrowser.js";
 import { getExternalBrowser } from "./getters.js";
+import * as launchEvent from "Shared/generated/launchEvent.js";
 
 import {
   applyPlatformContextMenus,
@@ -92,23 +93,17 @@ export async function handleBrowserNameChange() {
 export async function handleContextMenuClick(info, tab) {
   if (info.menuItemId === "launchInExternalBrowser") {
     if (await launchBrowser(tab)) {
-      browser.storage.local.set({
-        telemetry: {
-          type: "browserLaunch",
-          browser: await getExternalBrowser(),
-          source: "page_context_menu",
-        },
+      launchEvent.browserLaunch.record({
+        browser: await getExternalBrowser(),
+        source: "page_context_menu",
       });
     }
   } else if (info.menuItemId === "launchInExternalBrowserLink") {
     tab.url = info.linkUrl;
     if (await launchBrowser(tab)) {
-      browser.storage.local.set({
-        telemetry: {
-          type: "browserLaunch",
-          browser: await getExternalBrowser(),
-          source: "link_context_menu",
-        },
+      launchEvent.browserLaunch.record({
+        browser: await getExternalBrowser(),
+        source: "link_context_menu",
       });
     }
   } else if (info.menuItemId === "openWelcomePage") {

--- a/src/shared/backgroundScripts/hotkeys.js
+++ b/src/shared/backgroundScripts/hotkeys.js
@@ -1,5 +1,6 @@
 import { launchBrowser } from "Interfaces/launchBrowser.js";
 import { getExternalBrowser } from "./getters.js";
+import * as launchEvent from "Shared/generated/launchEvent.js";
 
 /**
  * Launches the user set browser on hotkey press.
@@ -10,22 +11,16 @@ import { getExternalBrowser } from "./getters.js";
 export async function handleHotkeyPress(command, tab) {
   if (command === "launchBrowser") {
     if (await launchBrowser(tab)) {
-      browser.storage.local.set({
-        telemetry: {
-          type: "browserLaunch",
-          browser: await getExternalBrowser(),
-          source: "hotkey",
-        },
+      launchEvent.browserLaunch.record({
+        browser: await getExternalBrowser(),
+        source: "hotkey",
       });
     }
   } else if (command === "launchFirefoxPrivate") {
     if (await launchBrowser(tab, true)) {
-      browser.storage.local.set({
-        telemetry: {
-          type: "browserLaunch",
-          browser: "Firefox Private Browsing",
-          source: "hotkey",
-        },
+      launchEvent.browserLaunch.record({
+        browser: "Firefox Private Browsing",
+        source: "hotkey",
       });
     }
   }

--- a/src/shared/backgroundScripts/telemetry.js
+++ b/src/shared/backgroundScripts/telemetry.js
@@ -48,7 +48,7 @@ export function initTelemetryListeners() {
     }
   });
 
-  browser.storage.onChanged.addListener(async (changes) => {
+  browser.storage.sync.onChanged.addListener(async (changes) => {
     if (changes.telemetryEnabled !== undefined) {
       await initGlean();
       Glean.setUploadEnabled(changes.telemetryEnabled.newValue);

--- a/src/shared/backgroundScripts/telemetry.js
+++ b/src/shared/backgroundScripts/telemetry.js
@@ -1,9 +1,6 @@
 import Glean from "@mozilla/glean/webext";
-import { install, startup, launch, settings } from "../generated/pings.js";
 import * as installEvent from "../generated/installEvent.js";
 import * as startupEvent from "../generated/startupEvent.js";
-import * as launchEvent from "../generated/launchEvent.js";
-import * as settingEvent from "../generated/settingEvent.js";
 
 import { getTelemetryEnabled } from "./getters.js";
 
@@ -33,7 +30,6 @@ export function initTelemetryListeners() {
     await initGlean();
     installEvent.dateInstalled.set(new Date());
     installEvent.browserType.set(IS_FIREFOX_EXTENSION ? "firefox" : "chromium");
-    install.submit();
   });
 
   browser.runtime.onStartup.addListener(async () => {
@@ -50,30 +46,10 @@ export function initTelemetryListeners() {
     for (const command of commands) {
       startupEvent.hotkeys[command.name.toLowerCase()].set(command.shortcut);
     }
-    startup.submit();
   });
 
   browser.storage.onChanged.addListener(async (changes) => {
-    if (changes.telemetry && changes.telemetry.newValue) {
-      await initGlean();
-      const telemetry = changes.telemetry.newValue;
-      if (telemetry.type === "browserLaunch") {
-        launchEvent.browserLaunch.record({
-          browser: telemetry.browser,
-          source: telemetry.source,
-        });
-        launch.submit();
-      }
-
-      if (telemetry.type === "currentBrowserChange") {
-        settingEvent.currentBrowser.from.set(telemetry.from);
-        settingEvent.currentBrowser.to.set(telemetry.to);
-        settingEvent.currentBrowser.source.set(telemetry.source);
-        settings.submit();
-      }
-
-      browser.storage.local.set({ telemetry: null });
-    } else if (changes.telemetryEnabled !== undefined) {
+    if (changes.telemetryEnabled !== undefined) {
       await initGlean();
       Glean.setUploadEnabled(changes.telemetryEnabled.newValue);
     }

--- a/src/shared/backgroundScripts/telemetry.js
+++ b/src/shared/backgroundScripts/telemetry.js
@@ -33,7 +33,7 @@ export function initTelemetryListeners() {
     if (details.reason === "install") {
       installEvent.dateInstalled.set(new Date());
       installEvent.browserType.set(
-        IS_FIREFOX_EXTENSION ? "firefox" : "chromium"
+        IS_FIREFOX_EXTENSION ? "firefox" : "chromium",
       );
     }
   });
@@ -45,7 +45,7 @@ export function initTelemetryListeners() {
     startupEvent.browserLanguageLocale.set(navigator.language);
     startupEvent.extensionLanguageLocale.set(browser.i18n.getUILanguage());
     startupEvent.isPinned.set(
-      (await browser.action.getUserSettings()).isOnToolbar
+      (await browser.action.getUserSettings()).isOnToolbar,
     );
     const commands = await browser.commands.getAll();
     for (const command of commands) {

--- a/src/shared/backgroundScripts/telemetry.js
+++ b/src/shared/backgroundScripts/telemetry.js
@@ -23,13 +23,11 @@ export async function initGlean(showLogs = false) {
  */
 export function initTelemetryListeners() {
   browser.runtime.onInstalled.addListener(async (details) => {
-    if (details.reason !== "install") {
-      return;
-    }
-
     await initGlean();
-    installEvent.dateInstalled.set(new Date());
-    installEvent.browserType.set(IS_FIREFOX_EXTENSION ? "firefox" : "chromium");
+    if (details.reason !== "install") {
+      installEvent.dateInstalled.set(new Date());
+      installEvent.browserType.set(IS_FIREFOX_EXTENSION ? "firefox" : "chromium");
+    }
   });
 
   browser.runtime.onStartup.addListener(async () => {

--- a/src/shared/backgroundScripts/telemetry.js
+++ b/src/shared/backgroundScripts/telemetry.js
@@ -26,7 +26,9 @@ export function initTelemetryListeners() {
     await initGlean();
     if (details.reason !== "install") {
       installEvent.dateInstalled.set(new Date());
-      installEvent.browserType.set(IS_FIREFOX_EXTENSION ? "firefox" : "chromium");
+      installEvent.browserType.set(
+        IS_FIREFOX_EXTENSION ? "firefox" : "chromium",
+      );
     }
   });
 

--- a/src/shared/backgroundScripts/telemetry.js
+++ b/src/shared/backgroundScripts/telemetry.js
@@ -24,7 +24,7 @@ export async function initGlean(showLogs = false) {
 export function initTelemetryListeners() {
   browser.runtime.onInstalled.addListener(async (details) => {
     await initGlean();
-    if (details.reason !== "install") {
+    if (details.reason === "install") {
       installEvent.dateInstalled.set(new Date());
       installEvent.browserType.set(
         IS_FIREFOX_EXTENSION ? "firefox" : "chromium",

--- a/src/shared/pages/welcomePage/browserList.js
+++ b/src/shared/pages/welcomePage/browserList.js
@@ -78,10 +78,11 @@ export async function populateBrowserList() {
       from: oldBrowserName,
       to: newBrowserName,
       source: "browser_list",
+    });
+
     const shortcutsList = document.getElementById("shortcuts-list");
     shortcutsList.innerHTML = "";
     await checkFirefoxHotkeys();
-    });
   });
 
   // Now select the proper browser.

--- a/src/shared/pages/welcomePage/browserList.js
+++ b/src/shared/pages/welcomePage/browserList.js
@@ -1,4 +1,5 @@
 import { getExternalBrowser } from "../../backgroundScripts/getters.js";
+import * as settingEvent from "../../generated/settingEvent.js";
 
 /**
  * Populate the browser list with the available browsers.
@@ -82,12 +83,10 @@ export async function populateBrowserList() {
     });
     browser.storage.sync.set({ currentExternalBrowser: newBrowserName });
 
-    browser.storage.local.set({
-      telemetry: {
-        type: "currentBrowserChange",
-        from: oldBrowserName,
-        to: newBrowserName,
-      },
+    settingEvent.currentBrowser.record({
+      from: oldBrowserName,
+      to: newBrowserName,
+      source: "browser_list",
     });
   });
 

--- a/src/shared/pages/welcomePage/script.js
+++ b/src/shared/pages/welcomePage/script.js
@@ -2,6 +2,7 @@ import {
   getExternalBrowser,
   getTelemetryEnabled,
 } from "../../backgroundScripts/getters.js";
+import * as settingEvent from "../../generated/settingEvent.js";
 
 import { applyLocalization, replaceMessage } from "./localization.js";
 import { populateBrowserList } from "./browserList.js";
@@ -37,13 +38,10 @@ export async function checkPrivateBrowsing() {
       alwaysPrivateCheckbox.checked = false;
     }
 
-    browser.storage.local.set({
-      telemetry: {
-        type: "currentBrowserChange",
-        from,
-        to,
-        source: "welcome_page",
-      },
+    settingEvent.currentBrowser.record({
+      from,
+      to,
+      source: "always_private_checkbox",
     });
   });
 }

--- a/src/shared/pages/welcomePage/script.js
+++ b/src/shared/pages/welcomePage/script.js
@@ -10,6 +10,7 @@ import { getIsFirefoxInstalled } from "Interfaces/getters.js";
 import { handleChangeDefaultLaunchContextMenuClick } from "Interfaces/contextMenus.js";
 
 import "Shared/backgroundScripts/polyfill.js";
+import { initGlean } from "Shared/backgroundScripts/telemetry.js";
 
 /**
  * Check the private browsing checkbox if the current external browser is
@@ -37,7 +38,7 @@ export async function checkPrivateBrowsing() {
     } else {
       alwaysPrivateCheckbox.checked = false;
     }
-
+    
     settingEvent.currentBrowser.record({
       from,
       to,
@@ -232,6 +233,7 @@ export function applyMobileLogic() {
 }
 
 document.addEventListener("DOMContentLoaded", function () {
+  initGlean();
   activatePlatformSpecificElements();
   applyLocalization();
   updateTelemetry();

--- a/src/shared/pages/welcomePage/script.js
+++ b/src/shared/pages/welcomePage/script.js
@@ -38,7 +38,7 @@ export async function checkPrivateBrowsing() {
     } else {
       alwaysPrivateCheckbox.checked = false;
     }
-    
+
     settingEvent.currentBrowser.record({
       from,
       to,

--- a/test/shared/backgroundScripts/telemetry.test.js
+++ b/test/shared/backgroundScripts/telemetry.test.js
@@ -1,9 +1,15 @@
 import { initTelemetryListeners } from "Shared/backgroundScripts/telemetry.js";
+import jest from "jest-mock";
+import Glean from "@mozilla/glean/webext";
+import { setExtensionPlatform } from "../../setup.test.js";
 
 describe("shared/backgroundScripts/telemetry.js", () => {
   describe("initTelemetryListeners()", () => {
-    it("should add the listeners", () => {
-      initTelemetryListeners();
+    it("should add the listeners", async () => {
+      Glean.initialize = jest.fn();
+      browser.runtime.getManifest = jest.fn(() => ({ version: "1.0.0" }));
+      setExtensionPlatform("firefox");
+      await initTelemetryListeners();
       expect(browser.runtime.onInstalled.addListener).toHaveBeenCalled();
       expect(browser.runtime.onStartup.addListener).toHaveBeenCalled();
       expect(browser.storage.sync.onChanged.addListener).toHaveBeenCalled();

--- a/test/shared/backgroundScripts/telemetry.test.js
+++ b/test/shared/backgroundScripts/telemetry.test.js
@@ -6,7 +6,7 @@ describe("shared/backgroundScripts/telemetry.js", () => {
       initTelemetryListeners();
       expect(browser.runtime.onInstalled.addListener).toHaveBeenCalled();
       expect(browser.runtime.onStartup.addListener).toHaveBeenCalled();
-      expect(browser.storage.onChanged.addListener).toHaveBeenCalled();
+      expect(browser.storage.sync.onChanged.addListener).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Use the glean API directly in each file. As per the [glean docs](https://mozilla.github.io/glean/book/user/pings/sent-by-glean.html), the pings set up will default to use events or metrics and be sent automatically with no input from me. This, however, means that you cannot see the specific ping info of the logs in the console using the glean API ([seen here](https://mozilla.github.io/glean/book/user/debugging/javascript.html)), but you can still see that the pings were sent. 

Everything to do with glean will get a data and code review in the future.

Code Review comments:
- https://github.com/mozilla/firefox-launch/pull/18/files#r1468913786