### PR TITLE
Code Review: Better firefox hotkey replacement

### DIFF
--- a/src/shared/pages/welcomePage/browserList.js
+++ b/src/shared/pages/welcomePage/browserList.js
@@ -1,4 +1,5 @@
 import { getExternalBrowser } from "../../backgroundScripts/getters.js";
+import { checkFirefoxHotkeys } from "./script.js";
 
 /**
  * Populate the browser list with the available browsers.
@@ -67,20 +68,14 @@ export async function populateBrowserList() {
       "data-launch-protocol",
     );
 
-    // update launch-browser-shortcut
-    const launchBrowserShortcutElement = document.getElementById(
-      "launch-browser-shortcut",
-    );
-    launchBrowserShortcutElement.innerText =
-      launchBrowserShortcutElement.innerText.replace(
-        oldBrowserName,
-        newBrowserName,
-      );
-
     browser.storage.local.set({
       currentExternalBrowserLaunchProtocol: executable,
     });
     browser.storage.sync.set({ currentExternalBrowser: newBrowserName });
+
+    const shortcutsList = document.getElementById("shortcuts-list");
+    shortcutsList.innerHTML = "";
+    await checkFirefoxHotkeys();
 
     browser.storage.local.set({
       telemetry: {


### PR DESCRIPTION
This patch uses the existing firefox hotkey list populator when switching browsers instead of manually replacing the browser name.

Code Review comments:
- https://github.com/mozilla/firefox-launch/pull/18/files#r1468934628