### PR TITLE
Code Review: changes to startup listener

### DIFF
--- a/src/shared/backgroundScripts/contextMenus.js
+++ b/src/shared/backgroundScripts/contextMenus.js
@@ -20,7 +20,7 @@ export async function initContextMenu() {
     id: "launchInExternalBrowser",
     title: browser.i18n.getMessage(
       "launchInExternalBrowser",
-      defaultLaunchMode
+      defaultLaunchMode,
     ),
     contexts: ["page"],
     documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
@@ -31,14 +31,14 @@ export async function initContextMenu() {
     id: "launchInExternalBrowserLink",
     title: browser.i18n.getMessage(
       "launchInExternalBrowserLink",
-      defaultLaunchMode
+      defaultLaunchMode,
     ),
     contexts: ["link"],
     targetUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
   });
 
   const action = browser.browserAction ? "browser_action" : "action"; // mv2 vs mv3
-  
+
   //separator
   browser.contextMenus.create({
     id: "separator",
@@ -75,13 +75,13 @@ export async function handleBrowserNameChange() {
   browser.contextMenus.update("launchInExternalBrowser", {
     title: browser.i18n.getMessage(
       "launchInExternalBrowser",
-      defaultLaunchMode
+      defaultLaunchMode,
     ),
   });
   browser.contextMenus.update("launchInExternalBrowserLink", {
     title: browser.i18n.getMessage(
       "launchInExternalBrowserLink",
-      defaultLaunchMode
+      defaultLaunchMode,
     ),
   });
 }

--- a/src/shared/backgroundScripts/contextMenus.js
+++ b/src/shared/backgroundScripts/contextMenus.js
@@ -20,7 +20,7 @@ export async function initContextMenu() {
     id: "launchInExternalBrowser",
     title: browser.i18n.getMessage(
       "launchInExternalBrowser",
-      defaultLaunchMode,
+      defaultLaunchMode
     ),
     contexts: ["page"],
     documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
@@ -31,13 +31,14 @@ export async function initContextMenu() {
     id: "launchInExternalBrowserLink",
     title: browser.i18n.getMessage(
       "launchInExternalBrowserLink",
-      defaultLaunchMode,
+      defaultLaunchMode
     ),
     contexts: ["link"],
     targetUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
   });
 
-  const action = browser.action ? "action" : "browser_action"; // mv2 vs mv3
+  const action = browser.browserAction ? "browser_action" : "action"; // mv2 vs mv3
+  
   //separator
   browser.contextMenus.create({
     id: "separator",
@@ -74,13 +75,13 @@ export async function handleBrowserNameChange() {
   browser.contextMenus.update("launchInExternalBrowser", {
     title: browser.i18n.getMessage(
       "launchInExternalBrowser",
-      defaultLaunchMode,
+      defaultLaunchMode
     ),
   });
   browser.contextMenus.update("launchInExternalBrowserLink", {
     title: browser.i18n.getMessage(
       "launchInExternalBrowserLink",
-      defaultLaunchMode,
+      defaultLaunchMode
     ),
   });
 }

--- a/src/shared/backgroundScripts/listeners.js
+++ b/src/shared/backgroundScripts/listeners.js
@@ -10,12 +10,17 @@ import { handleBrowserNameChange } from "./contextMenus.js";
  * Initialize the listeners that are shared between Firefox and Chromium.
  */
 export function initSharedListeners() {
-  browser.runtime.onInstalled.addListener(async () => {
+  browser.runtime.onInstalled.addListener(async (details) => {
     // await getIsAutoRedirect(); // resolve to true on fresh install
-    browser.tabs.create({
-      url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
-    });
+    if (details.reason === "install") {
+      browser.tabs.create({
+        url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
+      });
+    }
     await initContextMenu();
+  });
+
+  browser.runtime.onStartup.addListener(async () => {
     await updateToolbarIcon();
   });
 

--- a/src/shared/backgroundScripts/listeners.js
+++ b/src/shared/backgroundScripts/listeners.js
@@ -18,6 +18,7 @@ export function initSharedListeners() {
       });
     }
     await initContextMenu();
+    await updateToolbarIcon();
   });
 
   browser.runtime.onStartup.addListener(async () => {

--- a/test/shared/backgroundScripts/contextMenus.test.js
+++ b/test/shared/backgroundScripts/contextMenus.test.js
@@ -27,7 +27,7 @@ describe("shared/backgroundScripts/contextMenus.js", () => {
       expect(browser.contextMenus.create).toHaveBeenCalledWith({
         id: "openWelcomePage",
         title: getLocaleMessage("openWelcomePage"),
-        contexts: ["action"],
+        contexts: ["browser_action"],
       });
     });
   });


### PR DESCRIPTION
On install, ensure that the welcome page is only opened on first install of the extension. Update the icon on startup instead of just on install.

Code Review comments:
- https://github.com/mozilla/firefox-launch/pull/18/files#r1468672447
- https://github.com/mozilla/firefox-launch/pull/18/files#r1468908113