### PR TITLE
Code Review: launchApp refactor

### DIFF
--- a/src/firefox/api.js
+++ b/src/firefox/api.js
@@ -103,32 +103,46 @@ function _getAvailableBrowsersMac() {
   return appDataList;
 }
 
+function _getExecutablePathForBrowserWin(browserIdentifier) {
+  // either use the current getavailablebrowsers, or find a way
+  // to store the path here
+}
+
+function _getExecutablePathForBrowserMac(browserIdentifier) {
+  // either use the current getavailablebrowsers, or find a way
+  // to store the path here
+
+
+}
+
 /**
  * Launches an application on Windows.
  *
- * @param {*} appExecutable The executable file for an application
- * @param {*} handlerArgs The arguments to pass to the application
+ * @param {string} browserIdentifier The identifier of the browser to launch
+ * @param {string} url The URL to open
  */
-function _launchAppWin(appExecutable, handlerArgs) {
+function _launchAppWin(browserIdentifier, url) {
   let file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
   let process = Cc["@mozilla.org/process/util;1"].createInstance(Ci.nsIProcess);
+  let appExecutable = _getExecutablePathForBrowserWin(browserIdentifier);
   file.initWithPath(appExecutable);
   process.init(file);
-  process.run(false, handlerArgs, handlerArgs.length);
+  process.run(false, [url], 1);
 }
 
 /**
  * Launches an application on Mac.
  *
- * @param {*} appExecutable The executable file for an application
- * @param {*} handlerArgs The arguments to pass to the application
+ * @param {string} browserIdentifier The identifier of the browser to launch
+ * @param {string} url The URL to open
  */
-function _launchAppMac(appExecutable, handlerArgs) {
+function _launchAppMac(browserIdentifier, url) {
   let opener = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
   let process = Cc["@mozilla.org/process/util;1"].createInstance(Ci.nsIProcess);
+  let appExecutable = _getExecutablePathForBrowserMac(browserIdentifier);
   let uri = Services.io.newURI(appExecutable);
   let file = uri.QueryInterface(Ci.nsIFileURL).file;
-  let argsToUse = ["-a", file.path, ...handlerArgs];
+  let argsToUse = ["-a", file.path, url];
   opener.initWithPath("/usr/bin/open");
   process.init(opener);
   process.run(false, argsToUse, argsToUse.length);
@@ -185,14 +199,16 @@ this.experiments_firefox_launch = class extends ExtensionAPI {
           /**
            * Launches an application.
            *
-           * @param {*} appExecutable The executable file for an application
-           * @param {*} handlerArgs The arguments to pass to the application
+           * @param {string} browserIdentifier The identifier of the browser to launch
+           * @param {string} url The URL to open
            */
-          launchApp(appExecutable, handlerArgs) {
+          launchApp(browserIdentifier, url) {
+            let uri = Services.io.newURI(url[0]);
+
             if (AppConstants.platform == "win") {
-              _launchAppWin(appExecutable, handlerArgs);
+              _launchAppWin(browserIdentifier, uri.spec);
             } else if (AppConstants.platform == "macosx") {
-              _launchAppMac(appExecutable, handlerArgs);
+              _launchAppMac(browserIdentifier, uri.spec);
             }
           },
 

--- a/src/firefox/api.js
+++ b/src/firefox/api.js
@@ -184,16 +184,20 @@ this.experiments_firefox_launch = class extends ExtensionAPI {
           /**
            * Gets the available browsers to be potentially used for launching.
            *
-           * @returns {Promise<Array<{ name: string, executable: string }>}
+           * @returns {Promise<Array<string>}
            * The available browsers
            */
           async getAvailableBrowsers() {
+            let applist;
             if (AppConstants.platform == "win") {
-              return _getAvailableBrowsersWin();
+              applist = _getAvailableBrowsersWin();
             } else if (AppConstants.platform == "macosx") {
-              return _getAvailableBrowsersMac();
+              applist = _getAvailableBrowsersMac();
             }
-            return null;
+            // remove the executable field from each app data
+            return applist.map((app) => {
+              return app.name;
+            });
           },
 
           /**

--- a/src/firefox/interfaces/getters.js
+++ b/src/firefox/interfaces/getters.js
@@ -28,18 +28,4 @@ export async function getGreyedIconPath() {
   return { 32: browser.runtime.getURL(`images/${browserName}/32grey.png`) };
 }
 
-/**
- * Retrieve the current browser launch protocol from storage. If the browser is not
- * set, return an empty string.
- *
- * @returns {Promise<string>} The current browser launch protocol.
- */
-export async function getExternalBrowserLaunchProtocol() {
-  const result = await browser.storage.local.get(
-    "currentExternalBrowserLaunchProtocol",
-  );
-
-  return result.currentExternalBrowserLaunchProtocol || "";
-}
-
 export function getIsFirefoxInstalled() {}

--- a/src/firefox/interfaces/launchBrowser.js
+++ b/src/firefox/interfaces/launchBrowser.js
@@ -1,4 +1,4 @@
-import { getExternalBrowserLaunchProtocol } from "./getters.js";
+import { getExternalBrowser } from "Shared/backgroundScripts/getters.js";
 import { isURLValid } from "Shared/backgroundScripts/validTab.js";
 
 /**
@@ -22,13 +22,13 @@ export async function launchBrowser(url, usePrivateBrowsing = false) {
     return false;
   }
 
-  const launchProtocol = await getExternalBrowserLaunchProtocol();
-  if (launchProtocol) {
-    browser.experiments.firefox_launch.launchApp(launchProtocol, [url]);
-    return true;
+  const externalBrowser = await getExternalBrowser();
+  if (!externalBrowser) {
+    browser.tabs.create({
+      url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
+    });
+    return false;
   }
-  browser.tabs.create({
-    url: browser.runtime.getURL("shared/pages/welcomePage/index.html"),
-  });
-  return false;
+  browser.experiments.firefox_launch.launchBrowser(externalBrowser, url);
+  return true;
 }

--- a/src/firefox/schema.json
+++ b/src/firefox/schema.json
@@ -18,24 +18,20 @@
         "parameters": []
       },
       {
-        "name": "launchApp",
+        "name": "launchBrowser",
         "type": "function",
         "async": false,
-        "description": "Launches chosen app passed in",
+        "description": "Launches the specified browser with the given URL.",
         "parameters": [
           {
-            "name": "appExecutable",
+            "name": "browserIdentifier",
             "type": "string",
-            "description": "The path of the app to launch"
+            "description": "The identifier of the browser to launch"
           },
           {
-            "name": "handlerArgs",
-            "type": "array",
-            "description": "Array of arguments for the launched app",
-            "items": {
-              "type": "string",
-              "description": "Argument for the app"
-            }
+            "name": "url",
+            "type": "string",
+            "description": "The URL to open"
           }
         ]
       },

--- a/src/shared/pages/welcomePage/browserList.js
+++ b/src/shared/pages/welcomePage/browserList.js
@@ -10,13 +10,6 @@ export async function populateBrowserList() {
 
   const availableBrowsers =
     await browser.experiments.firefox_launch.getAvailableBrowsers();
-  console.log(availableBrowsers);
-
-  // console.group("Experimental Api Logs");
-  // availableBrowsers.logs.forEach((log) => {
-  //   console.log(log);
-  // });
-  // console.groupEnd();
 
   // if no browsers are available, remove the browser-list element and display a message
   if (availableBrowsers.length === 0) {
@@ -26,34 +19,25 @@ export async function populateBrowserList() {
     return;
   }
 
-  // sort browsers by name alphabetically and remove duplicate names
-  const loadedBrowsers = new Set();
-  const browsers = availableBrowsers
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .filter((localBrowser) => {
-      if (loadedBrowsers.has(localBrowser.name)) {
-        return false;
-      }
-      loadedBrowsers.add(localBrowser.name);
-      return true;
-    });
-
   const defaultBrowserName =
     await browser.experiments.firefox_launch.getDefaultBrowser();
+
+  // sort the browsers and remove duplicates
+  const browsers = [...new Set(availableBrowsers)].sort();
 
   // add browsers to the list
   browsers.forEach((localBrowser) => {
     const option = document.createElement("option");
-    option.value = localBrowser.name;
+    option.value = localBrowser;
 
     // if it's the user's default browser, add a message to the option
-    const isDefaultBrowser = defaultBrowserName === localBrowser.name;
+    const isDefaultBrowser = defaultBrowserName === localBrowser;
     if (isDefaultBrowser) {
-      option.text = `${localBrowser.name} ${browser.i18n.getMessage(
+      option.text = `${localBrowser} ${browser.i18n.getMessage(
         "welcomePageDefaultBrowser",
       )}`;
     } else {
-      option.text = localBrowser.name;
+      option.text = localBrowser;
     }
     browserList.appendChild(option);
   });

--- a/src/shared/pages/welcomePage/browserList.js
+++ b/src/shared/pages/welcomePage/browserList.js
@@ -55,8 +55,6 @@ export async function populateBrowserList() {
     } else {
       option.text = localBrowser.name;
     }
-
-    option.setAttribute("data-launch-protocol", localBrowser.executable);
     browserList.appendChild(option);
   });
 
@@ -64,13 +62,7 @@ export async function populateBrowserList() {
   browserList.addEventListener("change", async (event) => {
     const oldBrowserName = await getExternalBrowser();
     const newBrowserName = event.target.value;
-    const executable = event.target.selectedOptions[0].getAttribute(
-      "data-launch-protocol",
-    );
 
-    browser.storage.local.set({
-      currentExternalBrowserLaunchProtocol: executable,
-    });
     browser.storage.sync.set({ currentExternalBrowser: newBrowserName });
 
     const shortcutsList = document.getElementById("shortcuts-list");

--- a/test/firefox/interfaces/getters.test.js
+++ b/test/firefox/interfaces/getters.test.js
@@ -1,7 +1,6 @@
 import {
   getDefaultIconPath,
   getGreyedIconPath,
-  getExternalBrowserLaunchProtocol,
 } from "../../../src/firefox/interfaces/getters.js";
 import { setStorage } from "../../setup.test.js";
 
@@ -39,20 +38,6 @@ describe("firefox/interfaces/getters.js", () => {
       expect(result).toStrictEqual({
         32: browser.runtime.getURL("images/firefox-launch/32.png"),
       });
-    });
-  });
-
-  describe("getExternalBrowserLaunchProtocol()", () => {
-    it("should return the current external browser launch protocol", async () => {
-      await setStorage("currentExternalBrowserLaunchProtocol", "test");
-      const result = await getExternalBrowserLaunchProtocol();
-      expect(result).toEqual("test");
-    });
-
-    it("should return an empty string if no current external browser launch protocol", async () => {
-      await setStorage("currentExternalBrowserLaunchProtocol", undefined);
-      const result = await getExternalBrowserLaunchProtocol();
-      expect(result).toEqual("");
     });
   });
 });

--- a/test/firefox/interfaces/launchBrowser.test.js
+++ b/test/firefox/interfaces/launchBrowser.test.js
@@ -13,7 +13,7 @@ describe("firefox/interfaces/launchBrowser.js", () => {
     });
 
     it("should return false and open the welcome page if there is no launch protocol", async () => {
-      await setStorage("currentExternalBrowserLaunchProtocol", "");
+      await setStorage("currentExternalBrowser", "");
       const result = await launchBrowser("https://example.com");
       expect(result).toEqual(false);
       expect(browser.tabs.create).toHaveBeenCalled();
@@ -23,14 +23,15 @@ describe("firefox/interfaces/launchBrowser.js", () => {
     });
 
     it("should return true if there is a launch protocol", async () => {
-      await setStorage("currentExternalBrowserLaunchProtocol", "test");
+      await setStorage("currentExternalBrowser", "test");
       const result = await launchBrowser("https://example.com");
       expect(result).toEqual(true);
-      expect(browser.experiments.firefox_launch.launchApp).toHaveBeenCalled();
-      expect(browser.experiments.firefox_launch.launchApp).toHaveBeenCalledWith(
-        "test",
-        ["https://example.com"],
-      );
+      expect(
+        browser.experiments.firefox_launch.launchBrowser,
+      ).toHaveBeenCalled();
+      expect(
+        browser.experiments.firefox_launch.launchBrowser,
+      ).toHaveBeenCalledWith("test", "https://example.com");
     });
 
     it("should return false if the browser is launched in private mode", async () => {

--- a/test/firefox/interfaces/launchBrowser.test.js
+++ b/test/firefox/interfaces/launchBrowser.test.js
@@ -12,7 +12,7 @@ describe("firefox/interfaces/launchBrowser.js", () => {
       console.error.mockRestore();
     });
 
-    it("should return false and open the welcome page if there is no launch protocol", async () => {
+    it("should return false and open the welcome page if there is no set browser", async () => {
       await setStorage("currentExternalBrowser", "");
       const result = await launchBrowser("https://example.com");
       expect(result).toEqual(false);
@@ -22,7 +22,7 @@ describe("firefox/interfaces/launchBrowser.js", () => {
       });
     });
 
-    it("should return true if there is a launch protocol", async () => {
+    it("should return true if there is a set browser", async () => {
       await setStorage("currentExternalBrowser", "test");
       const result = await launchBrowser("https://example.com");
       expect(result).toEqual(true);

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -100,7 +100,7 @@ global.browser = {
     firefox_launch: {
       getAvailableBrowsers: jest.fn(),
       getDefaultBrowser: jest.fn(),
-      launchApp: jest.fn(),
+      launchBrowser: jest.fn(),
     },
   },
 };


### PR DESCRIPTION
A pretty involved patch. The goal is to make launchApp safer by only taking in the browser identifier and the url. To do this, a helper function `_getExecutablePathForBrowser` was created that calls `_getAvailableBrowsers` again and matches the browser identifier to the executable path. This ensures the only apps that can be launched are within the list given by `getAvailableBrowsers` at all times. The executable path is never seen in the main extension.

For the url, I attempted to sanitize by creating a URI object and checking the schema. I am not sure if this is exhaustive of all security cases.

The content of `_getAvailableBrowsers` has not changed much yet, as that is for future patches. 

Code review comments:
- https://github.com/mozilla/firefox-launch/pull/18/files#r1468903044