### PR TITLE
Code review: pageUrl usage

### DIFF
--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -55,7 +55,7 @@ export async function applyPlatformContextMenus() {
 
   // page context menu
   browser.contextMenus.create({
-    id: "launchInExternalBrowserPrivate",
+    id: "launchInExternalBrowserPrivatePage",
     title: browser.i18n.getMessage(
       "launchInExternalBrowser",
       "Firefox Private Browsing",
@@ -140,8 +140,8 @@ export async function handlePlatformContextMenuClick(info, tab) {
         },
       });
     }
-  } else if (info.menuItemId === "launchInExternalBrowserPrivate") {
-    if (await launchBrowser(tab.url, true)) {
+  } else if (info.menuItemId === "launchInExternalBrowserPrivatePage") {
+    if (await launchBrowser(info.pageUrl, true)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",

--- a/src/shared/backgroundScripts/contextMenus.js
+++ b/src/shared/backgroundScripts/contextMenus.js
@@ -17,7 +17,7 @@ export async function initContextMenu() {
 
   // page context menu
   browser.contextMenus.create({
-    id: "launchInExternalBrowser",
+    id: "launchInExternalBrowserPage",
     title: browser.i18n.getMessage(
       "launchInExternalBrowser",
       defaultLaunchMode,
@@ -72,7 +72,7 @@ export async function handleBrowserNameChange() {
   // if we're in chromium, ensure we force Firefox as the option, otherwise use the default
   const defaultLaunchMode = IS_FIREFOX_EXTENSION ? externalBrowser : "Firefox";
 
-  browser.contextMenus.update("launchInExternalBrowser", {
+  browser.contextMenus.update("launchInExternalBrowserPage", {
     title: browser.i18n.getMessage(
       "launchInExternalBrowser",
       defaultLaunchMode,
@@ -93,8 +93,8 @@ export async function handleBrowserNameChange() {
  * @param {Object} tab The tab object to launch the browser with.
  */
 export async function handleContextMenuClick(info, tab) {
-  if (info.menuItemId === "launchInExternalBrowser") {
-    if (await launchBrowser(tab.url)) {
+  if (info.menuItemId === "launchInExternalBrowserPage") {
+    if (await launchBrowser(info.pageUrl)) {
       browser.storage.local.set({
         telemetry: {
           type: "browserLaunch",

--- a/test/chromium/interfaces/contextMenus.test.js
+++ b/test/chromium/interfaces/contextMenus.test.js
@@ -26,7 +26,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
         contexts: ["action"],
       });
       expect(browser.contextMenus.create).toHaveBeenCalledWith({
-        id: "launchInExternalBrowserPrivate",
+        id: "launchInExternalBrowserPrivatePage",
         title: getLocaleMessage("launchInExternalBrowser"),
         contexts: ["page"],
         documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],

--- a/test/shared/backgroundScripts/contextMenus.test.js
+++ b/test/shared/backgroundScripts/contextMenus.test.js
@@ -13,7 +13,7 @@ describe("shared/backgroundScripts/contextMenus.js", () => {
       setExtensionPlatform("chromium");
       await initContextMenu();
       expect(browser.contextMenus.create).toHaveBeenCalledWith({
-        id: "launchInExternalBrowser",
+        id: "launchInExternalBrowserPage",
         title: getLocaleMessage("launchInExternalBrowser"),
         contexts: ["page"],
         documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],


### PR DESCRIPTION
Change tab.url to info.pageUrl for the page context menus. Also rename such contexts for more clarity.

Code Review comments:
- https://github.com/mozilla/firefox-launch/pull/18/files#r1468670953