### PR TITLE
Make context menu init sync

### DIFF
--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -21,18 +21,18 @@ export async function applyPlatformContextMenus() {
       type: "checkbox",
       checked: !(externalBrowserName === "Firefox"),
     },
-    handleDuplicateIDError
+    handleDuplicateIDError,
   );
   await browser.contextMenus.create(
     {
       id: "alternativeLaunchContextMenu",
       title: browser.i18n.getMessage(
         "launchInExternalBrowser",
-        alternateBrowserName
+        alternateBrowserName,
       ),
       contexts: ["action"],
     },
-    handleDuplicateIDError
+    handleDuplicateIDError,
   );
 
   // separator
@@ -42,7 +42,7 @@ export async function applyPlatformContextMenus() {
       type: "separator",
       contexts: ["action"],
     },
-    handleDuplicateIDError
+    handleDuplicateIDError,
   );
 
   // External sites context menu
@@ -76,12 +76,12 @@ export async function applyPlatformContextMenus() {
       id: "launchInExternalBrowserPrivatePage",
       title: browser.i18n.getMessage(
         "launchInExternalBrowser",
-        "Firefox Private Browsing"
+        "Firefox Private Browsing",
       ),
       contexts: ["page"],
       documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
     },
-    handleDuplicateIDError
+    handleDuplicateIDError,
   );
 
   // link context menu
@@ -90,12 +90,12 @@ export async function applyPlatformContextMenus() {
       id: "launchInExternalBrowserPrivateLink",
       title: browser.i18n.getMessage(
         "launchInExternalBrowserLink",
-        "Firefox Private Browsing"
+        "Firefox Private Browsing",
       ),
       contexts: ["link"],
       targetUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
     },
-    handleDuplicateIDError
+    handleDuplicateIDError,
   );
 }
 
@@ -112,7 +112,7 @@ export async function handleChangeDefaultLaunchContextMenuClick() {
   browser.contextMenus.update("alternativeLaunchContextMenu", {
     title: browser.i18n.getMessage(
       "launchInExternalBrowser",
-      externalBrowserName
+      externalBrowserName,
     ),
   });
 

--- a/src/chromium/interfaces/contextMenus.js
+++ b/src/chromium/interfaces/contextMenus.js
@@ -13,7 +13,7 @@ export async function applyPlatformContextMenus() {
     externalBrowserName === "Firefox" ? "Firefox Private Browsing" : "Firefox";
 
   // action context menu
-  browser.contextMenus.create(
+  await browser.contextMenus.create(
     {
       id: "changeDefaultLaunchContextMenu",
       title: browser.i18n.getMessage("changeDefaultLaunchContextMenu"),
@@ -21,18 +21,28 @@ export async function applyPlatformContextMenus() {
       type: "checkbox",
       checked: !(externalBrowserName === "Firefox"),
     },
-    handleDuplicateIDError,
+    handleDuplicateIDError
   );
-  browser.contextMenus.create(
+  await browser.contextMenus.create(
     {
       id: "alternativeLaunchContextMenu",
       title: browser.i18n.getMessage(
         "launchInExternalBrowser",
-        alternateBrowserName,
+        alternateBrowserName
       ),
       contexts: ["action"],
     },
-    handleDuplicateIDError,
+    handleDuplicateIDError
+  );
+
+  // separator
+  await browser.contextMenus.create(
+    {
+      id: "separator2",
+      type: "separator",
+      contexts: ["action"],
+    },
+    handleDuplicateIDError
   );
 
   // External sites context menu
@@ -61,31 +71,31 @@ export async function applyPlatformContextMenus() {
   // });
 
   // page context menu
-  browser.contextMenus.create(
+  await browser.contextMenus.create(
     {
       id: "launchInExternalBrowserPrivatePage",
       title: browser.i18n.getMessage(
         "launchInExternalBrowser",
-        "Firefox Private Browsing",
+        "Firefox Private Browsing"
       ),
       contexts: ["page"],
       documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
     },
-    handleDuplicateIDError,
+    handleDuplicateIDError
   );
 
   // link context menu
-  browser.contextMenus.create(
+  await browser.contextMenus.create(
     {
       id: "launchInExternalBrowserPrivateLink",
       title: browser.i18n.getMessage(
         "launchInExternalBrowserLink",
-        "Firefox Private Browsing",
+        "Firefox Private Browsing"
       ),
       contexts: ["link"],
       targetUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
     },
-    handleDuplicateIDError,
+    handleDuplicateIDError
   );
 }
 
@@ -102,7 +112,7 @@ export async function handleChangeDefaultLaunchContextMenuClick() {
   browser.contextMenus.update("alternativeLaunchContextMenu", {
     title: browser.i18n.getMessage(
       "launchInExternalBrowser",
-      externalBrowserName,
+      externalBrowserName
     ),
   });
 

--- a/src/shared/backgroundScripts/contextMenus.js
+++ b/src/shared/backgroundScripts/contextMenus.js
@@ -29,7 +29,7 @@ export async function initContextMenu() {
   const defaultLaunchMode = IS_FIREFOX_EXTENSION ? externalBrowser : "Firefox";
 
   // page context menu
-  browser.contextMenus.create(
+  await browser.contextMenus.create(
     {
       id: "launchInExternalBrowserPage",
       title: browser.i18n.getMessage(
@@ -43,7 +43,7 @@ export async function initContextMenu() {
   );
 
   // link context menu
-  browser.contextMenus.create(
+  await browser.contextMenus.create(
     {
       id: "launchInExternalBrowserLink",
       title: browser.i18n.getMessage(
@@ -59,7 +59,7 @@ export async function initContextMenu() {
   const action = browser.browserAction ? "browser_action" : "action"; // mv2 vs mv3
 
   //separator
-  browser.contextMenus.create(
+  await browser.contextMenus.create(
     {
       id: "separator",
       type: "separator",
@@ -71,18 +71,8 @@ export async function initContextMenu() {
   // platform specific menu
   await applyPlatformContextMenus();
 
-  //separator
-  browser.contextMenus.create(
-    {
-      id: "separator2",
-      type: "separator",
-      contexts: [action],
-    },
-    handleDuplicateIDError,
-  );
-
   // action menu welcome page
-  browser.contextMenus.create(
+  await browser.contextMenus.create(
     {
       id: "openWelcomePage",
       title: browser.i18n.getMessage("openWelcomePage"),

--- a/test/chromium/interfaces/contextMenus.test.js
+++ b/test/chromium/interfaces/contextMenus.test.js
@@ -22,7 +22,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
           type: "checkbox",
           checked: false,
         },
-        handleDuplicateIDError
+        handleDuplicateIDError,
       );
       expect(browser.contextMenus.create).toHaveBeenCalledWith(
         {
@@ -30,7 +30,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
           title: getLocaleMessage("launchInExternalBrowser"),
           contexts: ["action"],
         },
-        handleDuplicateIDError
+        handleDuplicateIDError,
       );
       expect(browser.contextMenus.create).toHaveBeenCalledWith(
         {
@@ -39,7 +39,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
           contexts: ["page"],
           documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
         },
-        handleDuplicateIDError
+        handleDuplicateIDError,
       );
       expect(browser.contextMenus.create).toHaveBeenCalledWith(
         {
@@ -47,7 +47,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
           type: "separator",
           contexts: ["action"],
         },
-        handleDuplicateIDError
+        handleDuplicateIDError,
       );
     });
   });
@@ -62,7 +62,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
         "alternativeLaunchContextMenu",
         {
           title: getLocaleMessage("launchInExternalBrowser"),
-        }
+        },
       );
       expect(browser.storage.sync.set).toHaveBeenCalledWith({
         currentExternalBrowser: "Firefox Private Browsing",
@@ -79,7 +79,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
         "alternativeLaunchContextMenu",
         {
           title: getLocaleMessage("launchInExternalBrowser"),
-        }
+        },
       );
       expect(browser.storage.sync.set).toHaveBeenCalledWith({
         currentExternalBrowser: "Firefox",

--- a/test/chromium/interfaces/contextMenus.test.js
+++ b/test/chromium/interfaces/contextMenus.test.js
@@ -13,7 +13,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
   describe("applyPlatformContextMenus()", () => {
     it("should create the chrome context menu", async () => {
       await applyPlatformContextMenus();
-      expect(browser.contextMenus.create).toHaveBeenCalledTimes(4);
+      expect(browser.contextMenus.create).toHaveBeenCalledTimes(5);
       expect(browser.contextMenus.create).toHaveBeenCalledWith(
         {
           id: "changeDefaultLaunchContextMenu",
@@ -22,7 +22,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
           type: "checkbox",
           checked: false,
         },
-        handleDuplicateIDError,
+        handleDuplicateIDError
       );
       expect(browser.contextMenus.create).toHaveBeenCalledWith(
         {
@@ -30,7 +30,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
           title: getLocaleMessage("launchInExternalBrowser"),
           contexts: ["action"],
         },
-        handleDuplicateIDError,
+        handleDuplicateIDError
       );
       expect(browser.contextMenus.create).toHaveBeenCalledWith(
         {
@@ -39,7 +39,15 @@ describe("chromium/interfaces/contextMenus.js", () => {
           contexts: ["page"],
           documentUrlPatterns: ["http://*/*", "https://*/*", "file:///*"],
         },
-        handleDuplicateIDError,
+        handleDuplicateIDError
+      );
+      expect(browser.contextMenus.create).toHaveBeenCalledWith(
+        {
+          id: "separator2",
+          type: "separator",
+          contexts: ["action"],
+        },
+        handleDuplicateIDError
       );
     });
   });
@@ -54,7 +62,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
         "alternativeLaunchContextMenu",
         {
           title: getLocaleMessage("launchInExternalBrowser"),
-        },
+        }
       );
       expect(browser.storage.sync.set).toHaveBeenCalledWith({
         currentExternalBrowser: "Firefox Private Browsing",
@@ -71,7 +79,7 @@ describe("chromium/interfaces/contextMenus.js", () => {
         "alternativeLaunchContextMenu",
         {
           title: getLocaleMessage("launchInExternalBrowser"),
-        },
+        }
       );
       expect(browser.storage.sync.set).toHaveBeenCalledWith({
         currentExternalBrowser: "Firefox",


### PR DESCRIPTION
Adds await to each create call. Opted for this method over updating async attributes later for ease of implementation and readability. Also moved a separator to chromium specific action menu to avoid duplicate ones in firefox.

Code review comments:
- https://github.com/mozilla/firefox-launch/pull/18/files#r1468672268