### PR TITLE
Prevent external browser reset on install events

### DIFF
--- a/src/chromium/interfaces/listeners.js
+++ b/src/chromium/interfaces/listeners.js
@@ -1,5 +1,4 @@
 import { launchBrowser } from "./launchBrowser.js";
-import { getIsFirefoxInstalled } from "./getters.js";
 import { getExternalBrowser } from "Shared/backgroundScripts/getters.js";
 import * as launchEvent from "Shared/generated/launchEvent.js";
 
@@ -42,7 +41,5 @@ export function initPlatformListeners() {
 
   browser.runtime.onInstalled.addListener(async () => {
     registerEventRules();
-    await getIsFirefoxInstalled();
-    browser.storage.sync.set({ currentExternalBrowser: "Firefox" });
   });
 }

--- a/src/shared/backgroundScripts/getters.js
+++ b/src/shared/backgroundScripts/getters.js
@@ -6,7 +6,7 @@
 export async function getExternalBrowser() {
   const result = await browser.storage.sync.get("currentExternalBrowser");
   if (!result || result.currentExternalBrowser === undefined) {
-    await browser.storage.sync.set({ currentExternalBrowser: "Firefox" });
+    browser.storage.sync.set({ currentExternalBrowser: "Firefox" });
     return "Firefox";
   }
   return result.currentExternalBrowser;

--- a/src/shared/backgroundScripts/getters.js
+++ b/src/shared/backgroundScripts/getters.js
@@ -6,7 +6,7 @@
 export async function getExternalBrowser() {
   const result = await browser.storage.sync.get("currentExternalBrowser");
   if (!result || result.currentExternalBrowser === undefined) {
-    browser.storage.sync.set({ currentExternalBrowser: "Firefox" });
+    await browser.storage.sync.set({ currentExternalBrowser: "Firefox" });
     return "Firefox";
   }
   return result.currentExternalBrowser;


### PR DESCRIPTION
Fixes #58 

When the default browser was changed from Firefox to Firefox Private Browsing and then the extension was reloaded, there would be a call to, on install, set the default browser back to Firefox.  This was here from some older code, but serves no purpose as on a call to `getExternalBrowser()` (the only time we retrieve this data), if there is no existing data, the function creates it. 

Similar story for `getIsFirefoxInstalled()`, there is no need to call it there as the function itself already handles the empty case.