### PR TITLE
Add UA parsing for telemetry

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -21,6 +21,34 @@ install_event:
     send_in_pings:
       - events
     description: |
+      The type of the browser the extension is running on (chromium vs firefox)
+    bugs:
+      - https://linktobugs.page
+    data_reviews:
+      - https://linktodatareviews.page
+    notification_emails:
+      - gsherman@mozilla.com
+    expires: never
+  browser_version:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - events
+    description: |
+      The name of the browser the extension is running on
+    bugs:
+      - https://linktobugs.page
+    data_reviews:
+      - https://linktodatareviews.page
+    notification_emails:
+      - gsherman@mozilla.com
+    expires: never
+  browser_name:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - events
+    description: |
       The name of the browser the extension is running on
     bugs:
       - https://linktobugs.page
@@ -107,6 +135,48 @@ startup_event:
       - events
     description: |
       Which hotkeys are set for each command
+    bugs:
+      - https://linktobugs.page
+    data_reviews:
+      - https://linktodatareviews.page
+    notification_emails:
+      - gsherman@mozilla.com
+    expires: never
+  browser_name:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - events
+    description: |
+      The name of the user's browser
+    bugs:
+      - https://linktobugs.page
+    data_reviews:
+      - https://linktodatareviews.page
+    notification_emails:
+      - gsherman@mozilla.com
+    expires: never
+  browser_version:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - events
+    description: |
+      The version of the user's browser
+    bugs:
+      - https://linktobugs.page
+    data_reviews:
+      - https://linktodatareviews.page
+    notification_emails:
+      - gsherman@mozilla.com
+    expires: never
+  external_browser:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - events
+    description: |
+      The name of the user's set external browser (Firefox only)
     bugs:
       - https://linktobugs.page
     data_reviews:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@mozilla/glean": "^2.0.0"
+        "@mozilla/glean": "^2.0.0",
+        "ua-parser-js": "^1.0.37"
       },
       "devDependencies": {
         "@babel/core": "^7.23.9",
@@ -12454,6 +12455,28 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
+      "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "chrome-types": "^0.1.246",
     "copy-webpack-plugin": "^12.0.2",
     "eslint": "^8.54.0",
-    "eslint-plugin-mozilla": "^3.3.2",
     "eslint-plugin-jest": "^27.6.3",
+    "eslint-plugin-mozilla": "^3.3.2",
     "eslint-plugin-no-unsanitized": "^4.0.2",
     "jest": "^29.7.0",
     "prettier": "^3.2.4",
@@ -59,6 +59,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "@mozilla/glean": "^2.0.0"
+    "@mozilla/glean": "^2.0.0",
+    "ua-parser-js": "^1.0.37"
   }
 }

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -128,6 +128,10 @@ global.document = {
   addEventListener: jest.fn(),
 };
 
+global.navigator = {
+  userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+};
+
 export const setSyncStorage = async (key, keyValue) => {
   let data = {};
   if (global.browser.storage.sync.get.mock) {


### PR DESCRIPTION
Uses UAParser library to get telemetry information from the useragent. Adds the remaining fields required by the spec.